### PR TITLE
Add sample harmony-api config.json

### DIFF
--- a/harmony-api/config/config.json.sample
+++ b/harmony-api/config/config.json.sample
@@ -1,0 +1,11 @@
+{
+  "enableHTTPserver": true,
+  "mqtt_host": "mqtt://localhost",
+  "topic_namespace": "harmony-api",
+  "mqtt_options": {
+      "port": 1883,
+      "username": "harmony-api",
+      "password": "sosecret",
+      "rejectUnauthorized": false
+  }
+}


### PR DESCRIPTION
The main thing of note is that the mqtt host should be localhost, because harmony-api is running with
net=host, so it'd be localhost on the mqtt port.

Fixes https://github.com/technicalpickles/picklehome/issues/1