### PR TITLE
Add apcupsd service

### DIFF
--- a/bin/apcaccess
+++ b/bin/apcaccess
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+exec docker-compose exec apcupsd apcaccess "$@"
+


### PR DESCRIPTION
This is the non-homeassistant part of https://github.com/technicalpickles/picklehome/issues/2

I tried a few different docker images, and ended up on https://hub.docker.com/r/retrohunter/apcupsd-cgi/ . Despite the name, it's not actually a CGI thing.

Other attempts included https://hub.docker.com/r/remonlam/apcupsd/ which only supported ARM, and https://hub.docker.com/r/obiwancanoweme/apcupsd/ which didn't have any documentation or a link to GitHub.

Also add a wrapper for calling apcaccess for figuring out what sensors to add to homeassistant.