### PR TITLE
script/deploy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,11 @@ services:
     image: homeassistant/home-assistant
     restart: always
     depends_on:
-      - mqtt
       - apcupsd
+      - harmony-api
+      - mqtt
+      - samba
+      - sonos
     ports:
       - 8123:8123
     volumes:

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+set -e
+
+container=$(docker-compose ps -q home-assistant)
+
+if [[ -n "${container}" ]]; then
+  bin/homeassistant --script check_config
+fi
+
+docker-compose stop home-assistant
+docker-compose up -d home-assistant
+
+container=$(docker-compose ps -q home-assistant)
+docker attach --sig-proxy=false "${container}"


### PR DESCRIPTION
Now that I've been developing this for awhile, I figure I had a good sense of how I develop/deploy:

1. I've made a few helpers in `bin`, so I can exec hass inside the running container, so I can run `bin/homeassistant --script check_config` to validate changes before restarting hass.

2. I tended to run `docker-compose up home-assistant`, and would control-c to stop, and use history to start it up again.

I've combined these, plus one other feature. Instead of running `docker-compose up home-assistant` directly, I run `docker-compose up -d home-assistant`, and then attach to the newly running component. That gives me logs, while control-c doesn't actually kill it. The next time `script/deploy` runs it handles stopping it first.