### PR TITLE
Fix samba discovery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,12 +59,15 @@ services:
 
   samba:
     image: dperson/samba
-    command: -n -s videos;/mount/videos -u kodi;${SAMBA_KODI_PASSWORD}
+    command: -n -s videos;/mount/videos -g "netbios name = picklehome" -u kodi;${SAMBA_KODI_PASSWORD}
     ports:
+      - 137:137/udp
+      - 138:138/udp
       - 139:139
       - 445:445
     volumes:
       - ./data:/mount:ro
+    network_mode: "host"
 
 volumes:
   mqtt-data:


### PR DESCRIPTION
This fixes https://github.com/technicalpickles/picklehome/issues/35

- use host networking
- expose nmbd ports
- also rename host to picklehome, instead of the default NEXT-UNIT-O as it got truncated to