### PR TITLE
Avahi alias

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     network_mode: "host"
 
   avahi-alias:
+    privileged: true # required for dbus access
     image: flqw/avahi-alias:latest
     volumes:
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,13 @@ services:
       - home-assistant
     network_mode: "host"
 
+  avahi-alias:
+    image: flqw/avahi-alias:latest
+    volumes:
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+    command:
+      - homeassistant.local
+
   sonos:
     image: chrisns/docker-node-sonos-http-api
     restart: always

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,6 +14,7 @@ http {
 
     server {
         listen 80;
+        server_name picklehome.local homeassistant.local
         access_log /var/log/nginx/access.log compression;
         proxy_headers_hash_max_size 512;
         proxy_buffering off;


### PR DESCRIPTION
Work towards https://github.com/technicalpickles/picklehome/issues/42

Without `privileged`, you'll get:

```
avahi-alias_1     | Traceback (most recent call last):
avahi-alias_1     |   File "/usr/local/bin/avahi-alias", line 77, in <module>
avahi-alias_1     |     publisher.publish_all()
avahi-alias_1     |   File "/usr/local/bin/avahi-alias", line 40, in publish_all
avahi-alias_1     |     self.publish_cname(cname)
avahi-alias_1     |   File "/usr/local/bin/avahi-alias", line 43, in publish_cname
avahi-alias_1     |     bus = dbus.SystemBus()
avahi-alias_1     |   File "/usr/lib/python2.7/dist-packages/dbus/_dbus.py", line 194, in __new__
avahi-alias_1     |     private=private)
avahi-alias_1     |   File "/usr/lib/python2.7/dist-packages/dbus/_dbus.py", line 100, in __new__
avahi-alias_1     |     bus = BusConnection.__new__(subclass, bus_type, mainloop=mainloop)
avahi-alias_1     |   File "/usr/lib/python2.7/dist-packages/dbus/bus.py", line 122, in __new__
avahi-alias_1     |     bus = cls._new_for_bus(address_or_type, mainloop=mainloop)
avahi-alias_1     | dbus.exceptions.DBusException: org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender="(null)" (inactive) interface="org.freedesktop.DBus" member="Hello" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus)
```