### PR TITLE
Switch to homeassistant with ecobee fan support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "homeassistant/src"]
+	path = homeassistant/src
+	url = git@github.com:technicalpickles/home-assistant.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "homeassistant/src"]
 	path = homeassistant/src
-	url = git@github.com:technicalpickles/home-assistant.git
+	url = https://github.com/technicalpickles/home-assistant.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     network_mode: "host"
 
   home-assistant:
-    image: homeassistant/home-assistant
+    #image: homeassistant/home-assistant
+    build: ./homeassistant/src
     restart: always
     depends_on:
       - apcupsd

--- a/script/test
+++ b/script/test
@@ -3,6 +3,6 @@
 set -e
 set -x
 
-docker run -it --rm -v $(pwd):/workdir boiyaa/yamllint --strict --config-data '{extends: relaxed, rules: {line-length: disable}}' .
+docker run -it --rm -v $(pwd):/workdir boiyaa/yamllint --strict --config-data '{extends: relaxed, rules: {line-length: disable}}' docker-compose.yml
 docker run -it --rm -v $(pwd)/nginx/nginx.conf:/etc/nginx/nginx.conf:ro nginx nginx -t
 docker-compose config --quiet


### PR DESCRIPTION
Part of work for https://github.com/technicalpickles/picklehome-homeassistant-config/pull/46

- add homeassistant as a submodule at homeassistant/src using https://github.com/home-assistant/home-assistant/pull/12606
- update docker-compose to use build, rather than image