### PR TITLE
homeassistant 0.64 upgrade path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     network_mode: "host"
 
   home-assistant:
-    image: homeassistant/home-assistant
+    image: homeassistant/home-assistant:0.63.3
     restart: always
     depends_on:
       - apcupsd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     network_mode: "host"
 
   home-assistant:
-    image: homeassistant/home-assistant:0.63.3
+    image: homeassistant/home-assistant:0.64.3
     restart: always
     depends_on:
       - apcupsd


### PR DESCRIPTION
This upgrades to home-assistant 0.64.3. I'm also switching to explicitly using a version, rather than an implied `latest`.

cc https://github.com/technicalpickles/picklehome-homeassistant-config/issues/45 https://github.com/technicalpickles/picklehome-homeassistant-config/pull/48