### PR TITLE
Use less `network_mode: host`, clean out old things, prepare for unifi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,25 +180,17 @@ services:
       - influxdb
       - prometheus
     restart: always
-    network_mode: host
 
   alertmanager:
-    #image: prom/alertmanager
     build:
       context: ./alertmanager/
       args:
         - slack_channel=$ALERTMANAGER_SLACK_CHANNEL
         - slack_webhook_url=$ALERTMANAGER_SLACK_WEBHOOK_URL
-    network_mode: host
-    #entrypoint: /bin/sh
-    #volumes:
-    #  - ./alertmanager/:/etc/alertmanager/
     command:
       - '--config.file=/etc/alertmanager/config.yml'
       - '--storage.path=/alertmanager'
     restart: always
-    expose:
-      - 9093
 
   #airconnect:
   #  restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,16 +185,16 @@ services:
       - certbot-var:/var/lib/letsencrypt
       - certbot-log:/var/logs/letsencrypt
 
-  unifi:
-    image: jacobalberty/unifi:stable
-    restart: always
-    ports:
-      - "8080:8080"
-      - "8443:8443"
-      - "6789:6789"
-      - "3478:3478/udp"
-      - "10001:10001/udp"
-      - "1900:1900/udp"
+ #unifi:
+ #  image: jacobalberty/unifi:stable
+ #  restart: always
+ #  ports:
+ #    - "8080:8080"
+ #    - "8443:8443"
+ #    - "6789:6789"
+ #    - "3478:3478/udp"
+ #    - "10001:10001/udp"
+ #    - "1900:1900/udp"
 
 volumes:
   mqtt-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,8 +140,7 @@ services:
     restart: always
     privileged: true
     ports:
-      - "8080:8080"
-    network_mode: "host"
+      - "18080:8080"
     volumes:
       - "/:/rootfs:ro"
       - "/var/run:/var/run:rw"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,6 @@ services:
 
   certbot:
     image: certbot/dns-dnsimple
-    network_mode: "none"
     volumes:
       - ./certbot/dnsimple.ini:/etc/dnsimple.ini
       - certbot-etc:/etc/letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,16 +11,16 @@ services:
       - mqtt-data:/mosquitto/data
       - ./mqtt/config:/mosquitto/config
 
-  harmony-api:
-    image: jonmaddox/harmony-api
-    restart: always
-    depends_on:
-      - mqtt
-    ports:
-      - 8282:8282
-    volumes:
-      - ./harmony-api/config:/config
-    network_mode: "host"
+  #harmony-api:
+  #  image: jonmaddox/harmony-api
+  #  restart: always
+  #  depends_on:
+  #    - mqtt
+  #  ports:
+  #    - 8282:8282
+  #  volumes:
+  #    - ./harmony-api/config:/config
+  #  network_mode: "host"
 
   homeassistant:
     image: homeassistant/home-assistant:0.82.1
@@ -227,6 +227,7 @@ services:
       - plex-config:/config
       - plex-transcode:/transcode
       - ./data:/data
+
   duckdns:
     restart: unless-stopped
     image: linuxserver/duckdns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
     #  - mqtt
     #  - sonos
     #  - influxdb
-    ports:
-      - 8123:8123
     volumes:
       - ./homeassistant/config:/config
     tty: true # so we get colors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,6 +244,17 @@ services:
       - certbot-var:/var/lib/letsencrypt
       - certbot-log:/var/logs/letsencrypt
 
+  unifi:
+    image: jacobalberty/unifi:stable
+    restart: always
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "6789:6789"
+      - "3478:3478/udp"
+      - "10001:10001/udp"
+      - "1900:1900/udp"
+
 volumes:
   mqtt-data:
   sonos-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,6 +234,7 @@ services:
       - .env.duckdns
     environment:
       - TZ
+
   certbot:
     image: certbot/dns-dnsimple
     network_mode: "none"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,9 @@ services:
       - 9090:9090
     volumes:
       - prometheus-data:/prometheus-data
-    network_mode: "host"
+    extra_hosts:
+      - "homeassistant:${DOCKER_IP}"
+      - "docker:${DOCKER_IP}"
 
   # For reference in case? Use host os instead
   #node-exporter:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,20 +199,20 @@ services:
     expose:
       - 9093
 
-  airconnect:
-    restart: always
-    build: airconnect
-    network_mode: host
-    command:
-      - "-d"
-      - all=info
-      - "-b"
-      - ":49152"
-      - "-x"
-      - /config/config.xml
-      - "-Z"
-    volumes:
-      - ./airconnect/config:/config
+  #airconnect:
+  #  restart: always
+  #  build: airconnect
+  #  network_mode: host
+  #  command:
+  #    - "-d"
+  #    - all=info
+  #    - "-b"
+  #    - ":49152"
+  #    - "-x"
+  #    - /config/config.xml
+  #    - "-Z"
+  #  volumes:
+  #    - ./airconnect/config:/config
 
   plex:
     container_name: plex

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,17 +11,6 @@ services:
       - mqtt-data:/mosquitto/data
       - ./mqtt/config:/mosquitto/config
 
-  #harmony-api:
-  #  image: jonmaddox/harmony-api
-  #  restart: always
-  #  depends_on:
-  #    - mqtt
-  #  ports:
-  #    - 8282:8282
-  #  volumes:
-  #    - ./harmony-api/config:/config
-  #  network_mode: "host"
-
   homeassistant:
     image: homeassistant/home-assistant:0.82.1
     #build: ./homeassistant/src
@@ -38,7 +27,6 @@ services:
     network_mode: "host"
 
   nginx:
-    #image: nginx
     build:
       context: ./nginx/
       args:
@@ -49,7 +37,6 @@ services:
       - 80:80
       - 443:443
     volumes:
-#      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/dhparam.pem:/etc/nginx/dhparam.pem:ro
       - certbot-etc:/etc/letsencrypt
     depends_on:
@@ -99,7 +86,6 @@ services:
     network_mode: "host"
 
   prometheus:
-    #image: prom/prometheus
     build:
       context: ./prometheus/
       args:
@@ -112,26 +98,6 @@ services:
     extra_hosts:
       - "homeassistant:${DOCKER_IP}"
       - "docker:${DOCKER_IP}"
-
-  # For reference in case? Use host os instead
-  #node-exporter:
-  #  image: prom/node-exporter
-  #  restart: always
-  #  user: root
-  #  privileged: true
-  #  ports:
-  #    - "9100:9100"
-  #  volumes:
-  #    - "/proc:/host/proc:ro"
-  #    - "/sys:/host/sys:ro"
-  #    - "/:/host:ro,rslave"
-  #  network_mode: "host"
-  #  pid: "host"
-  #  command:
-  #    - "--path.procfs=/host/proc"
-  #    - "--path.sysfs=/host/sys"
-  #    #- '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host/var/lib/snapd/hostfs/var/lib/lxcfs|host/var/lib/snapd)($$|/)'
-  #    #- '--collector.filesystem.ignored-fs-types=^(aufs|autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|efivarfs|fusectl|hugetlbfs|lxcfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|squashfs|sysfs|tmpfs|tracefs)$$'
 
   cadvisor:
     image: google/cadvisor:latest
@@ -189,21 +155,6 @@ services:
       - '--config.file=/etc/alertmanager/config.yml'
       - '--storage.path=/alertmanager'
     restart: always
-
-  #airconnect:
-  #  restart: always
-  #  build: airconnect
-  #  network_mode: host
-  #  command:
-  #    - "-d"
-  #    - all=info
-  #    - "-b"
-  #    - ":49152"
-  #    - "-x"
-  #    - /config/config.xml
-  #    - "-Z"
-  #  volumes:
-  #    - ./airconnect/config:/config
 
   plex:
     container_name: plex

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -28,16 +28,16 @@ scrape_configs:
     bearer_token: "%%bearer_token%%"
     scheme: http
     static_configs:
-      - targets: ['localhost:8123']
+      - targets: ['homeassistant:8123']
 
   - job_name: 'node-exporter'
     static_configs:
-      - targets: ['localhost:9100']
+      - targets: ['docker:9100']
 
   - job_name: 'cadvisor'
     scrape_interval: 5s
     static_configs:
-      - targets: ['localhost:8080']
+      - targets: ['cadvisor:8080']
 
 alerting:
   alertmanagers:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -44,6 +44,6 @@ alerting:
   - scheme: http
     static_configs:
     - targets: 
-      - 'localhost:9093'
-      #- 'alertmanager:9093'
+      #- 'localhost:9093'
+      - 'alertmanager:9093'
 


### PR DESCRIPTION
Originally started this out for https://github.com/technicalpickles/picklehome/issues/73 . The use of `network_mode: host` caused some problems using it initially, because cadadvisor was already using port 8080, and unifi wanted it too.

I dropped a few of the containers to regular type networking which allowed that to proceed. Basically, for places that need access to the host's ports, I add an `extra_hosts` entry. For readability, I use the same name of the container that provides the thing.

I did get the unifi controller running, but I had problems with adopting the first switch. Between that, and separating concerns, I ended up picking up a unifi cloud key.