### PR TITLE
0.84 upgrade path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./mqtt/config:/mosquitto/config
 
   homeassistant:
-    image: homeassistant/home-assistant:0.83.3
+    image: homeassistant/home-assistant:0.84.3
     #build: ./homeassistant/src
     restart: always
     #depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./mqtt/config:/mosquitto/config
 
   homeassistant:
-    image: homeassistant/home-assistant:0.82.1
+    image: homeassistant/home-assistant:0.83.3
     #build: ./homeassistant/src
     restart: always
     #depends_on:


### PR DESCRIPTION
Upgrade to [homeassistant 0.84](https://www.home-assistant.io/blog/2018/12/12/release-84/)