### PR TITLE
feat(brineworks-agent): mobile agent service + workspace deploy key

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -277,6 +277,43 @@ brineworks-server-logs host="picklelab" lines="50":
 brineworks-server-logs-follow host="picklelab":
     ssh -t {{host}} "cd /opt/homelab/homelab/services/brineworks-server && docker compose -f compose.yaml -f compose.picklelab.yaml logs -f"
 
+# Deploy Brineworks mobile agent to picklelab (idempotent: first setup or update)
+deploy-brineworks-agent host="picklelab":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "ERROR: uncommitted changes. Commit or stash first."
+        exit 1
+    fi
+    BRANCH=$(git branch --show-current)
+    if [ "$BRANCH" != "main" ]; then
+        echo "ERROR: not on main (on $BRANCH). Switch to main first."
+        exit 1
+    fi
+    LOCAL=$(git rev-parse HEAD)
+    REMOTE=$(git rev-parse origin/main)
+    if [ "$LOCAL" != "$REMOTE" ]; then
+        echo "Pushing to origin/main..."
+        git push
+    fi
+    echo "Deploying commit $(git rev-parse --short HEAD) to {{host}}"
+    echo "==> Pulling on {{host}}"
+    ssh {{host}} "cd /opt/homelab && git pull"
+    echo "==> Copying .env to {{host}}"
+    mkdir -p tmp
+    scripts/service-env homelab/services/brineworks-agent/.env.vars > tmp/brineworks-agent.env
+    scp tmp/brineworks-agent.env {{host}}:/opt/homelab/homelab/services/brineworks-agent/.env
+    rm tmp/brineworks-agent.env
+    ssh {{host}} "cd /opt/homelab && homelab/services/brineworks-agent/deploy.sh"
+
+# Tail Brineworks agent container logs from picklelab
+brineworks-agent-logs host="picklelab" lines="50":
+    ssh {{host}} "cd /opt/homelab/homelab/services/brineworks-agent && docker compose -f compose.yaml -f compose.picklelab.yaml logs --tail={{lines}}"
+
+# Follow Brineworks agent container logs live from picklelab
+brineworks-agent-logs-follow host="picklelab":
+    ssh -t {{host}} "cd /opt/homelab/homelab/services/brineworks-agent && docker compose -f compose.yaml -f compose.picklelab.yaml logs -f"
+
 # Tailscale VPN overlay: just tailscale [status]
 tailscale *ARGS:
     tailscale {{ if ARGS == "" { "status" } else { ARGS } }}

--- a/homelab/services/README.md
+++ b/homelab/services/README.md
@@ -116,6 +116,29 @@ See [brineworks-server/README.md](brineworks-server/README.md) for full setup.
 
 ---
 
+### brineworks-agent
+
+Always-on, phone-reachable Claude Code session running the brineworks CLI against prod. SSH + tmux into a container over Tailscale.
+
+| | |
+|---|---|
+| **Purpose** | Mobile agent surface: reach a full Claude Code + `bw` session from a phone |
+| **Compose** | `/srv/containers/brineworks-agent/` |
+| **Data** | `/srv/data/brineworks-agent/` (sshd host keys, cryptfile keyring, session workspace) |
+| **Access** | `ssh technicalpickles@brineworks-agent.<tailnet>.ts.net` (Tailscale Services, raw TCP to port 2222 internally) |
+| **Env vars** | `KEYRING_CRYPTFILE_PASSWORD`, `BRINEWORKS_API_KEY` (filtered `.env` only, never the master env) |
+| **Backup** | Not yet (needs adding to backup service) |
+| **Restart** | `restart: unless-stopped` |
+| **Source** | `technicalpickles/brineworks` (private repo), built from `/opt/brineworks` on host |
+
+The homelab's first **raw-TCP** Tailscale service (SSH, not HTTPS). Container internals copy `homelab/dev/`; deploy/orchestration shape copies `brineworks-server`.
+
+Commands: `just deploy-brineworks-agent`, `just brineworks-agent-logs`, `just brineworks-agent-logs-follow`
+
+See [brineworks-agent/README.md](brineworks-agent/README.md) for full setup.
+
+---
+
 ### taskchampion-sync
 
 Self-hosted Taskwarrior sync server. Replicates the Mac's `~/.task` to picklelab; encryption secret stays client-side, server only sees opaque blobs.

--- a/homelab/services/brineworks-agent/.env.vars
+++ b/homelab/services/brineworks-agent/.env.vars
@@ -1,5 +1,8 @@
 # Vars required by the brineworks-agent service.
 # Used by scripts/service-env to extract a minimal .env for deployment.
 # Only these secrets reach the container -- not the master /opt/homelab/.env.
+# Unknown names are skipped silently, so WORKSPACE_DEPLOY_KEY_B64 is a no-op
+# until its op:// reference is added to .env.template (see README prerequisites).
 KEYRING_CRYPTFILE_PASSWORD
 BRINEWORKS_API_KEY
+WORKSPACE_DEPLOY_KEY_B64

--- a/homelab/services/brineworks-agent/.env.vars
+++ b/homelab/services/brineworks-agent/.env.vars
@@ -1,0 +1,5 @@
+# Vars required by the brineworks-agent service.
+# Used by scripts/service-env to extract a minimal .env for deployment.
+# Only these secrets reach the container -- not the master /opt/homelab/.env.
+KEYRING_CRYPTFILE_PASSWORD
+BRINEWORKS_API_KEY

--- a/homelab/services/brineworks-agent/README.md
+++ b/homelab/services/brineworks-agent/README.md
@@ -1,0 +1,124 @@
+# Brineworks Agent
+
+An always-on, phone-reachable Claude Code session on picklelab that runs the brineworks CLI against prod. Reached over Tailscale by SSH; work happens in a long-lived tmux session. This is the mobile agent surface (brineworks [ADR 0005](https://github.com/technicalpickles/brineworks/blob/main/docs/decisions/0005-mobile-agent-surface.md)).
+
+**Source repo:** `technicalpickles/brineworks` (private). The image contract (`agent/Dockerfile`, entrypoint, the env vars it reads) lives there; this directory owns orchestration only (brineworks `docs/ops-principles.md` #4).
+
+## What it is
+
+A self-contained Ubuntu container with a real `sshd` (key-only, `authorized_keys` pulled from your GitHub keys), Claude Code, the brineworks CLI (`bw`), and tmux (resurrect/continuum). You SSH in from a phone, `tmux attach`, and you're in a full Claude Code session with `bw` wired to the prod server and prod Gmail.
+
+Modeled on `homelab/dev/` (the container internals: sshd, GitHub-keys auth, host keys on a volume) and `homelab/services/brineworks-server/` (the deploy/orchestration shape).
+
+## Prerequisites (one-time)
+
+The agent needs the cryptfile keyring master password in the `picklehome` 1Password vault, surfaced into the root `.env`:
+
+| Field | How to generate | Notes |
+|-------|-----------------|-------|
+| `KEYRING_CRYPTFILE_PASSWORD` | `openssl rand -base64 32` | Unlocks the in-container Gmail token keyring |
+
+`BRINEWORKS_API_KEY` is reused from the existing `Brineworks Server` item (the agent is a client of the same server). Add the `op://` reference for `KEYRING_CRYPTFILE_PASSWORD` to `.env.template` and run `just dotenv` (see the project [CLAUDE.md](../../../CLAUDE.md) "Secrets & Config").
+
+Your phone's SSH client public key must be in your GitHub keys (`https://github.com/technicalpickles.keys`) -- the entrypoint fetches that into `authorized_keys` on first boot.
+
+## First-time Setup
+
+```bash
+just dotenv          # pull secrets from 1Password (incl. KEYRING_CRYPTFILE_PASSWORD)
+just deploy-brineworks-agent
+```
+
+`deploy.sh` ensures the brineworks source clone at `/opt/brineworks` (lockstep with the server), creates the `/data` volume directories, configures Tailscale serve, builds the image, and starts the systemd service.
+
+### Approve the Tailscale service (first deploy only)
+
+This is the homelab's first **raw-TCP** Tailscale service (SSH, not HTTPS). On the first deploy the endpoint won't respond until you approve it:
+
+1. Open [Tailscale Services](https://login.tailscale.com/admin/services)
+2. Find `brineworks-agent` and approve the pending host advertisement
+3. Re-advertise (tailscaled doesn't auto-detect approval):
+   ```bash
+   sudo tailscale serve --service=svc:brineworks-agent --tcp=22 off
+   sleep 2
+   sudo tailscale serve --service=svc:brineworks-agent --tcp=22 tcp://127.0.0.1:2222
+   ```
+4. Verify: `ssh technicalpickles@brineworks-agent.<tailnet>.ts.net`
+
+`deploy.sh` prints these steps if the endpoint isn't reachable. If raw-TCP serve turns out unsupported, the fallback is to bind the published port to the host's tailscale IP (in `compose.picklelab.yaml`) instead of loopback and reach it as `picklelab:2222`.
+
+## Gmail bootstrap (one-time)
+
+The CLI reads its Gmail OAuth token from the cryptfile keyring on `/data`. Until `bw email auth --device` exists (brineworks M4), bootstrap is copy-the-token:
+
+1. On the Mac, auth with MODIFY scopes so the stored token can apply labels.
+2. Copy the resulting keyring file onto the volume at `/srv/data/brineworks-agent/keyring/cryptfile.cfg`.
+
+(The container can't run the interactive OAuth browser flow, so the token is minted on the Mac and dropped onto the volume.)
+
+## Connecting
+
+```bash
+ssh technicalpickles@brineworks-agent.<tailnet>.ts.net
+tmux attach            # or: tmux new -s main
+```
+
+The tmux session is long-lived and survives disconnects. A redeploy recreates the container and kills the live session; tmux-resurrect/continuum plus `~/.claude` on the volume restore the layout and conversation on reattach. In-flight pipeline runs are recovered by rerun (brineworks principle #13).
+
+## Deploying Updates
+
+```bash
+just deploy-brineworks-agent
+```
+
+Pulls latest `picklehome` and `brineworks`, rebuilds the image, restarts the service. Lockstep with `just deploy-brineworks-server` keeps the agent and server at the same brineworks SHA (the CLI talks to the server over a stable HTTP API, so SHA skew is safe if they ever drift).
+
+## Architecture
+
+- **Build from source:** the image builds from `/opt/brineworks` (whole repo, `agent/Dockerfile`) -- the same host clone the server builds from, kept fast-forwarded by `deploy.sh`. No published image.
+- **Compose layering:** `compose.yaml` is the portable base (`image: brineworks-agent:local`, non-secret config). `compose.picklelab.yaml` adds the `build:` directive, the loopback port bind, the `/data` volume, and the filtered `env_file`.
+- **Code vs. state:** the image bakes the brineworks code (frozen at the build SHA -- the container's analog of the Mac workspace's `repo` symlink + editable install). All durable state lives on the `/data` volume. The container owns no source checkout; to do dev work on brineworks, clone it ad hoc, same as you would on the Mac.
+- **Secrets:** the container receives **only** its filtered `.env` (`KEYRING_CRYPTFILE_PASSWORD`, `BRINEWORKS_API_KEY`), never the master `/opt/homelab/.env`. It runs arbitrary Claude sessions, so it gets the github-actions-runner treatment (`homelab/services/README.md`).
+- **Networking:** sshd binds `127.0.0.1:2222` (loopback only). `tailscale serve --tcp=22` proxies `brineworks-agent.<tailnet>.ts.net:22` to it. Re-applied on every deploy; idempotent.
+
+## Environment Variables
+
+Non-secret config is set in `compose.yaml`; secrets come from the filtered `.env` (`.env.vars` -> `scripts/service-env`).
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `BRINEWORKS_ENV` | compose | `production` -- every `bw` command hits the real server and Gmail |
+| `BRINEWORKS_SERVER_URL` | compose | `https://brineworks.<tailnet>.ts.net` (prod server, explicit URL wins) |
+| `BRINEWORKS_KEYRING_FILE` | compose | `/data/keyring/cryptfile.cfg` |
+| `BRINEWORKS_EMAIL_BASE_DIR` | compose | `/data/workspace/email/sessions` |
+| `PF_KEYCHAIN_PREFIX` | compose | `agent` (per-worktree macOS logic doesn't apply in-container) |
+| `KEYRING_CRYPTFILE_PASSWORD` | `.env` (1Password) | Master password for the cryptfile keyring |
+| `BRINEWORKS_API_KEY` | `.env` (1Password) | Bearer token for the prod server (same key as the server) |
+
+## Data Locations (on picklelab)
+
+```
+/opt/brineworks/                         # brineworks repo clone (shared build input)
+/srv/data/brineworks-agent/ssh/host_keys # persistent sshd host keys
+/srv/data/brineworks-agent/keyring/      # cryptfile Gmail token keyring
+/srv/data/brineworks-agent/workspace/    # email session workspace + scratch
+```
+
+The brineworks `agent/entrypoint.sh` also redirects durable user state onto the volume, so login and sessions survive redeploys:
+
+```
+/srv/data/brineworks-agent/claude/       # ~/.claude (.credentials.json, settings, transcripts)
+/srv/data/brineworks-agent/claude.json   # ~/.claude.json (OAuth + MCP state)
+/srv/data/brineworks-agent/tmux-resurrect # tmux-resurrect/continuum session saves
+```
+
+It also symlinks the baked skills into the workspace (`workspace/.claude/skills`), mirroring the Mac workspace's `setup`, so `/process-email` resolves from the session. (Triage rules live in the Obsidian vault, not the repo, so there's no `email/config` to link.)
+
+All of `/data` is backed up by picklehome's restic (once added to the backup service).
+
+## Logs
+
+```bash
+just brineworks-agent-logs
+just brineworks-agent-logs-follow
+```

--- a/homelab/services/brineworks-agent/README.md
+++ b/homelab/services/brineworks-agent/README.md
@@ -20,6 +20,26 @@ The agent needs the cryptfile keyring master password in the `picklehome` 1Passw
 
 `BRINEWORKS_API_KEY` is reused from the existing `Brineworks Server` item (the agent is a client of the same server). Add the `op://` reference for `KEYRING_CRYPTFILE_PASSWORD` to `.env.template` and run `just dotenv` (see the project [CLAUDE.md](../../../CLAUDE.md) "Secrets & Config").
 
+### Workspace deploy key (one-time)
+
+The agent clones and pushes the `technicalpickles/brineworks-workspace` repo (triage rules + session data) with a **scoped read-write deploy key** -- low blast radius (config data, no code), so AFK-capable push is acceptable (brineworks design doc).
+
+1. Generate an ed25519 keypair (no passphrase -- the container runs unattended):
+   ```bash
+   ssh-keygen -t ed25519 -f brineworks-workspace-deploy -C "brineworks-agent workspace deploy key" -N ""
+   ```
+2. Add the **public** key (`brineworks-workspace-deploy.pub`) to `technicalpickles/brineworks-workspace` -> Settings -> Deploy keys, **with "Allow write access" checked**.
+3. Store the **private** key base64-encoded in the `picklehome` 1Password vault, item `Brineworks Agent`, field `workspace_deploy_key_b64`:
+   ```bash
+   base64 < brineworks-workspace-deploy | pbcopy   # paste into the 1Password field
+   ```
+   (Base64 keeps it a single line so it survives `scripts/service-env`'s line-based filter; `deploy.sh` decodes it back to the key file on the volume.)
+4. Add the reference to `.env.template` (next to the other Brineworks vars) and re-run `just dotenv`:
+   ```
+   WORKSPACE_DEPLOY_KEY_B64={{ op://picklehome/Brineworks Agent/workspace_deploy_key_b64 }}
+   ```
+   `WORKSPACE_DEPLOY_KEY_B64` is already in `.env.vars`; until the `op://` reference exists it's skipped silently, and both `deploy.sh` and the entrypoint degrade to a bare workspace (no rules pipeline) with a warning. Delete the local keypair once it's in 1Password and on GitHub.
+
 Your phone's SSH client public key must be in your GitHub keys (`https://github.com/technicalpickles.keys`) -- the entrypoint fetches that into `authorized_keys` on first boot.
 
 ## First-time Setup
@@ -94,14 +114,16 @@ Non-secret config is set in `compose.yaml`; secrets come from the filtered `.env
 | `PF_KEYCHAIN_PREFIX` | compose | `agent` (per-worktree macOS logic doesn't apply in-container) |
 | `KEYRING_CRYPTFILE_PASSWORD` | `.env` (1Password) | Master password for the cryptfile keyring |
 | `BRINEWORKS_API_KEY` | `.env` (1Password) | Bearer token for the prod server (same key as the server) |
+| `WORKSPACE_DEPLOY_KEY_B64` | `.env` (1Password) | Base64 ed25519 deploy key; `deploy.sh` decodes it to `ssh/workspace_deploy_key` for the workspace clone/push |
 
 ## Data Locations (on picklelab)
 
 ```
-/opt/brineworks/                         # brineworks repo clone (shared build input)
-/srv/data/brineworks-agent/ssh/host_keys # persistent sshd host keys
-/srv/data/brineworks-agent/keyring/      # cryptfile Gmail token keyring
-/srv/data/brineworks-agent/workspace/    # email session workspace + scratch
+/opt/brineworks/                              # brineworks repo clone (shared build input)
+/srv/data/brineworks-agent/ssh/host_keys      # persistent sshd host keys
+/srv/data/brineworks-agent/ssh/workspace_deploy_key  # scoped brineworks-workspace deploy key (0600, uid 1000)
+/srv/data/brineworks-agent/keyring/           # cryptfile Gmail token keyring
+/srv/data/brineworks-agent/workspace/         # brineworks-workspace checkout (triage rules + session data)
 ```
 
 The brineworks `agent/entrypoint.sh` also redirects durable user state onto the volume, so login and sessions survive redeploys:
@@ -112,7 +134,7 @@ The brineworks `agent/entrypoint.sh` also redirects durable user state onto the 
 /srv/data/brineworks-agent/tmux-resurrect # tmux-resurrect/continuum session saves
 ```
 
-It also symlinks the baked skills into the workspace (`workspace/.claude/skills`), mirroring the Mac workspace's `setup`, so `/process-email` resolves from the session. (Triage rules live in the Obsidian vault, not the repo, so there's no `email/config` to link.)
+On boot the entrypoint also clones (or fast-forward-pulls) the `brineworks-workspace` repo into `workspace/` via the scoped deploy key, so the triage rules at `email/config/triage-rules.yaml` are present and current for the pipeline. It symlinks the baked skills into the workspace (`workspace/.claude/skills`), mirroring the Mac workspace's `setup`, so `/process-email` resolves from the session. Without the deploy key it falls back to a bare `workspace/` (no rules pipeline).
 
 All of `/data` is backed up by picklehome's restic (once added to the backup service).
 

--- a/homelab/services/brineworks-agent/brineworks-agent.service
+++ b/homelab/services/brineworks-agent/brineworks-agent.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Brineworks mobile agent (SSH + tmux + Claude Code container)
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/homelab/homelab/services/brineworks-agent
+# No EnvironmentFile: the compose files use no ${VAR} interpolation. Secrets
+# reach the container via env_file (.env, written by deploy.sh); non-secret
+# config is hardcoded in compose.yaml. So an empty systemd env is fine.
+ExecStart=/usr/bin/docker compose -f compose.yaml -f compose.picklelab.yaml up -d --build
+ExecStop=/usr/bin/docker compose -f compose.yaml -f compose.picklelab.yaml down
+
+[Install]
+WantedBy=multi-user.target

--- a/homelab/services/brineworks-agent/compose.picklelab.yaml
+++ b/homelab/services/brineworks-agent/compose.picklelab.yaml
@@ -1,0 +1,20 @@
+services:
+  agent:
+    build:
+      # Build context is the whole brineworks repo (the image bakes it into
+      # /opt/brineworks); the agent image lives at agent/Dockerfile. deploy.sh
+      # keeps /opt/brineworks fast-forwarded to main, lockstep with the server.
+      context: /opt/brineworks
+      dockerfile: agent/Dockerfile
+    # Filtered service secrets ONLY (KEYRING_CRYPTFILE_PASSWORD, BRINEWORKS_API_KEY).
+    # Deliberately NOT /opt/homelab/.env: this container runs arbitrary Claude
+    # sessions, so it must not receive the whole homelab secret set
+    # (cf. github-actions-runner, homelab/services/README.md).
+    env_file:
+      - .env
+    ports:
+      # Loopback only -- tailscale serve (--tcp=22) proxies
+      # brineworks-agent.<tailnet>:22 to this. 2222 is internal, not user-facing.
+      - "127.0.0.1:2222:22"
+    volumes:
+      - /srv/data/brineworks-agent:/data

--- a/homelab/services/brineworks-agent/compose.yaml
+++ b/homelab/services/brineworks-agent/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  agent:
+    image: brineworks-agent:local
+    restart: unless-stopped
+    # sshd host keys, the cryptfile keyring, the email session workspace, and
+    # ~/.claude all live on /data (mounted from the host in compose.picklelab.yaml).
+    # Non-secret config is set here; secrets come from the filtered .env via
+    # env_file in the picklelab overlay (never the master /opt/homelab/.env).
+    environment:
+      BRINEWORKS_ENV: production
+      BRINEWORKS_SERVER_URL: https://brineworks.tail2023b7.ts.net
+      BRINEWORKS_KEYRING_FILE: /data/keyring/cryptfile.cfg
+      BRINEWORKS_EMAIL_BASE_DIR: /data/workspace/email/sessions
+      # Fixed prefix: the per-worktree macOS keychain logic does not apply in-container.
+      PF_KEYCHAIN_PREFIX: agent

--- a/homelab/services/brineworks-agent/deploy.sh
+++ b/homelab/services/brineworks-agent/deploy.sh
@@ -41,6 +41,33 @@ sudo mkdir -p "$DATA_DIR/ssh/host_keys" "$DATA_DIR/keyring" "$DATA_DIR/workspace
 # root-created host keys fine (root can read uid-owned dirs).
 sudo chown -R "$CONTAINER_UID:$CONTAINER_GID" "$DATA_DIR"
 
+echo "==> Installing the workspace-repo deploy key (if provided)"
+# The agent clones/pushes the brineworks-workspace repo (triage rules + session
+# data) with a scoped read-write deploy key. It arrives base64-encoded in the
+# filtered .env (single line, so service-env's line-based filter keeps it whole)
+# and must land uid-owned 0600: ssh refuses a private key it does not own, and the
+# agent user both clones at boot and pushes interactively with it.
+# No Obsidian-vault mount is wired (grep -n 'pickled-knowledge\|obsidian'
+# compose.picklelab.yaml is empty); rules reach the agent via this clone, not a mount.
+ENV_FILE="$SERVICE_DIR/.env"
+DEPLOY_KEY_FILE="$DATA_DIR/ssh/workspace_deploy_key"
+KEY_B64=""
+if [ -f "$ENV_FILE" ]; then
+    KEY_B64=$(grep -m1 '^WORKSPACE_DEPLOY_KEY_B64=' "$ENV_FILE" | cut -d= -f2- || true)
+fi
+if [ -n "$KEY_B64" ]; then
+    # install /dev/null first so the file is 0600 + uid-owned before any bytes land
+    # (never world-readable); tee then fills it without changing mode or owner.
+    sudo install -m 600 -o "$CONTAINER_UID" -g "$CONTAINER_GID" /dev/null "$DEPLOY_KEY_FILE"
+    echo "$KEY_B64" | base64 -d | sudo tee "$DEPLOY_KEY_FILE" > /dev/null
+    echo "    Wrote $DEPLOY_KEY_FILE (0600, uid $CONTAINER_UID)"
+else
+    echo "    WARNING: WORKSPACE_DEPLOY_KEY_B64 not in $ENV_FILE."
+    echo "    The agent can't clone or push brineworks-workspace, so the rules"
+    echo "    pipeline is unavailable. Add WORKSPACE_DEPLOY_KEY_B64 to .env.vars +"
+    echo "    .env.template (see README 'Prerequisites'), re-run 'just dotenv', redeploy."
+fi
+
 echo "==> Configuring Tailscale serve (TCP) for brineworks-agent"
 # Registers brineworks-agent.<tailnet>.ts.net:22, raw-TCP passthrough to the
 # loopback-published sshd (SSH does its own crypto -- no TLS termination).

--- a/homelab/services/brineworks-agent/deploy.sh
+++ b/homelab/services/brineworks-agent/deploy.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Deploy the Brineworks mobile agent container on picklelab.
+# Idempotent: safe to run on first setup or any subsequent deploy.
+# Run from the repo root on the target host.
+set -euo pipefail
+
+REPO_DIR=/opt/homelab
+SERVICE_DIR="$REPO_DIR/homelab/services/brineworks-agent"
+DATA_DIR=/srv/data/brineworks-agent
+BRINEWORKS_REPO=/opt/brineworks
+# The in-container user (agent/Dockerfile USER_UID default). The /data volume
+# must be writable by this uid for the keyring and session workspace.
+CONTAINER_UID=1000
+CONTAINER_GID=1000
+# Internal sshd port (loopback-published by compose). tailscale serve maps the
+# service's public port 22 onto this.
+CONTAINER_SSH_PORT=2222
+
+cd "$REPO_DIR"
+
+echo "==> Deploying commit $(git rev-parse --short HEAD)"
+
+echo "==> Updating brineworks source (lockstep build input, shared with the server)"
+if [ -d "$BRINEWORKS_REPO/.git" ]; then
+    git -C "$BRINEWORKS_REPO" pull --ff-only
+else
+    echo "    Cloning brineworks to $BRINEWORKS_REPO"
+    sudo mkdir -p "$BRINEWORKS_REPO"
+    sudo chown "$(id -u):$(id -g)" "$BRINEWORKS_REPO"
+    git clone git@github.com:technicalpickles/brineworks.git "$BRINEWORKS_REPO"
+fi
+BRINEWORKS_SHA=$(git -C "$BRINEWORKS_REPO" rev-parse --short HEAD)
+echo "    Brineworks at $BRINEWORKS_SHA"
+
+echo "==> Creating data directories on the volume"
+# host_keys: sshd host keys (root-owned, written by the entrypoint).
+# keyring:   cryptfile keyring file (written by the agent as uid $CONTAINER_UID).
+# workspace: email session workspace + scratch (written by the agent).
+sudo mkdir -p "$DATA_DIR/ssh/host_keys" "$DATA_DIR/keyring" "$DATA_DIR/workspace"
+# Make the volume writable by the in-container user. sshd still reads its
+# root-created host keys fine (root can read uid-owned dirs).
+sudo chown -R "$CONTAINER_UID:$CONTAINER_GID" "$DATA_DIR"
+
+echo "==> Configuring Tailscale serve (TCP) for brineworks-agent"
+# Registers brineworks-agent.<tailnet>.ts.net:22, raw-TCP passthrough to the
+# loopback-published sshd (SSH does its own crypto -- no TLS termination).
+# First non-HTTPS Tailscale service in this homelab; if --tcp serve is
+# unsupported/fussy, the fallback is to bind the published port to the host's
+# tailscale IP instead of loopback and reach it as picklelab:$CONTAINER_SSH_PORT
+# (see the WARNING block at the end of this script).
+sudo tailscale serve --service=svc:brineworks-agent --tcp=22 "tcp://127.0.0.1:$CONTAINER_SSH_PORT"
+
+echo "==> Linking systemd unit"
+sudo ln -sf "$SERVICE_DIR/brineworks-agent.service" /etc/systemd/system/
+
+echo "==> Reloading systemd and restarting service"
+sudo systemctl daemon-reload
+sudo systemctl enable brineworks-agent.service
+sudo systemctl restart brineworks-agent.service
+
+echo "==> Status"
+systemctl status brineworks-agent.service --no-pager
+
+echo ""
+echo "==> Waiting for container sshd to accept connections on 127.0.0.1:$CONTAINER_SSH_PORT"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    if timeout 1 bash -c "cat < /dev/null > /dev/tcp/127.0.0.1/$CONTAINER_SSH_PORT" 2>/dev/null; then
+        echo "    sshd is accepting connections"
+        break
+    fi
+    if [ "$i" -eq 10 ]; then
+        echo "    WARNING: sshd not accepting connections after 10 attempts"
+        echo "    Check container logs: docker compose -f compose.yaml -f compose.picklelab.yaml logs"
+        exit 1
+    fi
+    echo "    Waiting for sshd (attempt $i/10)..."
+    sleep 2
+done
+
+TAILNET=$(tailscale status --json | jq -r '.CurrentTailnet.MagicDNSSuffix')
+AGENT_HOST="brineworks-agent.${TAILNET}"
+
+echo ""
+echo "==> Checking Tailscale service endpoint"
+if timeout 3 bash -c "cat < /dev/null > /dev/tcp/${AGENT_HOST}/22" 2>/dev/null; then
+    echo "    Tailscale service reachable at ${AGENT_HOST}:22"
+    echo ""
+    echo "Done! Connect with: ssh technicalpickles@${AGENT_HOST}"
+    echo "Then: tmux attach   (or tmux new -s main)"
+else
+    echo "    WARNING: Tailscale service not reachable at ${AGENT_HOST}:22"
+    echo ""
+    echo "    If this is the first deploy, approve the service:"
+    echo "    1. Open https://login.tailscale.com/admin/services"
+    echo "    2. Find 'brineworks-agent' and approve the pending host"
+    echo "    3. Re-advertise (tailscaled doesn't auto-detect approval):"
+    echo "       sudo tailscale serve --service=svc:brineworks-agent --tcp=22 off"
+    echo "       sleep 2"
+    echo "       sudo tailscale serve --service=svc:brineworks-agent --tcp=22 tcp://127.0.0.1:$CONTAINER_SSH_PORT"
+    echo "    4. Verify: ssh technicalpickles@${AGENT_HOST}"
+    echo ""
+    echo "    Fallback (if TCP serve isn't supported): change the compose port"
+    echo "    bind in compose.picklelab.yaml from 127.0.0.1:$CONTAINER_SSH_PORT to the"
+    echo "    host's tailscale IP, redeploy, then reach it directly:"
+    echo "       ssh -p $CONTAINER_SSH_PORT technicalpickles@picklelab.${TAILNET}"
+fi


### PR DESCRIPTION
The picklehome side of the mobile agent (brineworks ADR 0005): the compose service that runs the always-on, phone-reachable Claude Code session on picklelab, plus the workspace-repo deploy key wiring for Phase 5 of the versioned-triage-rules plan.

## What's here

**The service (M3 scaffold, `5473e8e`):** `compose.yaml` / `compose.picklelab.yaml` (sshd, loopback bind, `/data` volume, filtered env), the systemd unit, `deploy.sh` (build from `/opt/brineworks`, data dirs, Tailscale raw-TCP serve), the `just` recipes, and the service README. Modeled on `homelab/dev` (container internals) and `brineworks-server` (deploy shape).

**Workspace deploy key (`831e94c` docs, `22812d4` feat):** `deploy.sh` reads `WORKSPACE_DEPLOY_KEY_B64` from the filtered `.env`, base64-decodes it, and installs it at `ssh/workspace_deploy_key` as a uid-owned 0600 file (install `/dev/null` first so it's never world-readable, then `tee` fills it). The agent clones and pushes brineworks-workspace with it.

## Why base64

The key travels through the filtered `.env` so it reaches the host. `service-env` filters line by line, so a multi-line PEM would get truncated. base64 keeps it a single line, no quoting games, and it lands in the container env alongside the two existing service secrets (same posture).

## Degrades gracefully

`WORKSPACE_DEPLOY_KEY_B64` is in `.env.vars`, but `service-env` skips unknown names, so it's a no-op until the `op://` reference lands in `.env.template`. Both `deploy.sh` and the entrypoint warn and fall back to a bare workspace if the key is absent. So this is safe to merge before the key exists.

No Obsidian-vault mount is wired: rules reach the agent via the clone, not a bind mount.

## Before deploy (one-time, manual)

Generate the ed25519 deploy key, register the public key on the workspace repo with write access, store the base64 private key in 1Password, and add the `op://` reference to `.env.template`. Exact steps are in the service README under "Workspace deploy key".

Pairs with the entrypoint side: technicalpickles/brineworks#13.

Plan: brineworks `docs/plans/2026-06-07-versioned-triage-rules-agent-workspace-implementation.md` (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
