### PR TITLE
second-brain-agent: auto-attach interactive logins to tmux

### DIFF
--- a/homelab/services/second-brain-agent/Dockerfile
+++ b/homelab/services/second-brain-agent/Dockerfile
@@ -43,6 +43,10 @@ RUN mkdir /var/run/sshd \
 COPY homelab/services/second-brain-agent/tmux.conf /home/$USERNAME/.tmux.conf
 RUN chown $USER_UID:$USER_GID /home/$USERNAME/.tmux.conf
 
+# Auto-attach interactive ssh/mosh logins to the persistent `main` tmux session.
+# zz- prefix sources it last in profile.d (after anything written at runtime).
+COPY homelab/services/second-brain-agent/tmux-autoattach.sh /etc/profile.d/zz-tmux-autoattach.sh
+
 COPY homelab/services/second-brain-agent/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/homelab/services/second-brain-agent/README.md
+++ b/homelab/services/second-brain-agent/README.md
@@ -58,8 +58,13 @@ Credentials are now persisted at `/data/claude/.credentials.json`.
 
 ```bash
 ssh technicalpickles@second-brain-agent.<tailnet>.ts.net
-tmux attach            # or: tmux new -s main
 ```
+
+You land directly in the persistent `main` tmux session — a `/etc/profile.d` hook
+auto-attaches every interactive SSH/mosh login (the session is started detached at
+container boot, so it's always there). Detaching (`C-b d`) drops you to a plain shell;
+`tmux attach` gets you back in. Non-interactive channels (`scp`, `ssh host <cmd>`) are
+left alone.
 
 The vault is at `/vault/`. Use `claude` to start a session; ripgrep (`rg`) is available for full-text vault search.
 

--- a/homelab/services/second-brain-agent/deploy.sh
+++ b/homelab/services/second-brain-agent/deploy.sh
@@ -49,8 +49,8 @@ for i in 1 2 3 4 5 6 7 8 9 10; do
     echo "    Reachable at ${AGENT_HOST}:22"
     echo ""
     echo "Done! Connect with: ssh technicalpickles@${AGENT_HOST}"
-    echo "Then: tmux attach   (or tmux new -s main)"
-    echo "Phone (mosh): mosh technicalpickles@${AGENT_HOST} then tmux attach"
+    echo "  (you land straight in the persistent 'main' tmux session)"
+    echo "Phone (mosh): mosh technicalpickles@${AGENT_HOST}"
     exit 0
   fi
   echo "    Waiting for the node (attempt $i/10)..."

--- a/homelab/services/second-brain-agent/entrypoint.sh
+++ b/homelab/services/second-brain-agent/entrypoint.sh
@@ -41,4 +41,10 @@ ln -sf /data/claude.json "$HOME_DIR/.claude.json"
 # Ensure home dir ownership is correct
 chown "$USERNAME:$USERNAME" "$HOME_DIR"
 
+# Start a detached `main` tmux session as the user, rooted in the vault, so there's
+# always a session to attach to (continuum auto-restores into it from /data). The
+# zz-tmux-autoattach.sh profile.d hook lands interactive logins straight here.
+# `|| true`: a failed start must not block sshd from coming up.
+su - "$USERNAME" -c "tmux new-session -d -s main -c '${VAULT_DIR:-/vault}' || true"
+
 exec /usr/sbin/sshd -D

--- a/homelab/services/second-brain-agent/tmux-autoattach.sh
+++ b/homelab/services/second-brain-agent/tmux-autoattach.sh
@@ -1,0 +1,18 @@
+# Auto-attach interactive SSH/mosh logins to the persistent `main` tmux session.
+# Lands a phone (or laptop) straight in the running session instead of a bare shell.
+#
+# Guards, in order:
+#   case $- in *i*  -- interactive shells only. Skips the boot-time `su -c "tmux
+#                      new-session -d"` and any `ssh host cmd`, which are non-interactive.
+#   -z $TMUX        -- don't recurse: panes inside tmux already have TMUX set.
+#   -t 1            -- stdout is a real tty.
+# Detaching (or tmux failing) returns here and the login shell continues to a normal
+# prompt, so this is non-destructive: it never logs you out, it just defaults you in.
+case "$-" in
+  *i*)
+    if [ -z "${TMUX:-}" ] && [ -t 1 ] && command -v tmux >/dev/null 2>&1; then
+      tmux attach-session -t main 2>/dev/null \
+        || tmux new-session -s main -c /vault
+    fi
+    ;;
+esac


### PR DESCRIPTION
## What

SSH or mosh into the agent and you now land straight in the persistent `main` tmux session, instead of a bare shell where you have to type `tmux attach` yourself. This is the auto-connect brineworks-agent already has; second-brain-agent shipped without it.

Two pieces, both lifted from brineworks-agent:

- **Boot a session:** the entrypoint starts a detached `main` session (rooted at `$VAULT_DIR`, so you open right in the vault) as the user before `exec sshd`. There's always something to attach to, and continuum restores into it.
- **Attach on login:** `/etc/profile.d/zz-tmux-autoattach.sh` attaches interactive logins. The guards (interactive-only, not-already-in-tmux, real tty) keep `scp`, `ssh host <cmd>`, and nested panes out of it. Detaching just drops you to a normal shell, so it never traps you.

## Why this and not `ForceCommand`

`ForceCommand tmux ...` would hijack every channel, including file transfers and remote commands. The profile.d + interactive-guard approach only grabs interactive logins. Same call brineworks made.

## Validation

Built the image and checked the behavior end to end:

- interactive + tty login invokes `tmux attach-session -t main`
- non-interactive (`ssh host cmd` / scp) and no-tty channels do **not** attach and don't hang
- the boot-time detached session starts cleanly
- shellcheck clean on the new + changed scripts

Follows #89 (the original service). Separate followup still open: shared base agent image so this and brineworks-agent stop drifting on deps (taskwarrior `768e42db`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSEiETUr7QNqTbAp7CKiU2