### PR TITLE
docs: audit and fix CLAUDE.md + READMEs for accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,12 +145,13 @@ See @docs/CONVENTIONS.md for where information belongs (code comments vs README 
 - `locks/`: Yale Access smart locks; see `locks/README.md`
 - `sonos/`: Sonos speaker health checks (local, no auth); see `sonos/README.md`
 - `homelab/`: NUC server services and infrastructure; see `homelab/README.md`
-  - Key services: `obsidian-sync` (vaults: `rpg`, `pickled-knowledge`), `brineworks-server`, `brineworks-agent`, `second-brain-agent`, `taskchampion-sync`
+  - Key services: `obsidian-sync` (vaults: `rpg`, `pickled-knowledge`), `brineworks-server`, `brineworks-agent`, `second-brain-agent`, `taskchampion-sync`, `climate-auto-switch`, `backup`, `github-actions-runner`, `woodpecker` (full list in the Homelab Services table below)
   - **Obsidian vaults on host:** `/srv/data/obsidian-sync/vaults/<vault>/` — `pickled-knowledge` is the personal knowledge base (second brain); `rpg` is campaign notes
   - `second-brain-agent` mounts `pickled-knowledge` read-write at `/vault`, reachable at `ssh technicalpickles@second-brain-agent.<tailnet>.ts.net`
-- `docs/plans/`: Design documents and implementation plans
+- `docs/`: `plans/` (point-in-time design docs + implementation plans), `research/` (deep-dive findings), `CONVENTIONS.md`, `climate-setup.md`
 - `tests/`: pytest tests, mirroring source layout
 - `scripts/`: Shared utilities (`dotenv`, `service-env`, `quote-env-values`)
+- `_bmad/`, `_bmad-output/`: BMAD-method tooling and its output (not part of the home-automation code)
 
 ## Integrations
 
@@ -181,3 +182,7 @@ Always-on services on picklelab (NUC), managed via Docker Compose + systemd. See
 | brineworks-agent | `homelab/services/brineworks-agent/` | Always-on Claude Code session for email triage (SSH+mosh) | `just deploy-brineworks-agent` |
 | second-brain-agent | `homelab/services/second-brain-agent/` | Always-on Claude Code session with `pickled-knowledge` vault at `/vault` | `just deploy-second-brain-agent` |
 | taskchampion-sync | `homelab/services/taskchampion-sync/` | Self-hosted Taskwarrior sync server | `just deploy-taskchampion` |
+| climate-auto-switch | `homelab/services/climate-auto-switch/` | 15-min timer running seasonal HVAC comfort switching | `just deploy-climate`, `just climate-check`, `just climate-log` |
+| backup | `homelab/services/backup/` | Nightly restic backups of `/srv/data` (GFS retention) | `just deploy-backup`, `just backup-now`, `just backup-status` |
+| github-actions-runner | `homelab/services/github-actions-runner/` | Self-hosted GitHub Actions runner for the pirpg repo | `just deploy-github-runner`, `just github-runner-status` |
+| woodpecker | `homelab/services/woodpecker/` | Self-hosted Woodpecker CI for private repos (Funnel ingress) | `just deploy-woodpecker`, `just woodpecker-status` |

--- a/climate/README.md
+++ b/climate/README.md
@@ -138,13 +138,15 @@ The goal is always ~70°F in any actively occupied space. Comfort Heat and Comfo
 
 ```
 climate/
-  sync.py                  # Ecobee CLI entry point (argparse)
+  sync.py                  # Ecobee CLI (run as `python -m climate.sync`, argparse)
   blueair_cli.py           # BlueAir CLI entry point (argparse)
+  runlog.py                # Append-only JSONL run logging (used by auto-switch)
   ecobee/
     auth.py                # File-based OAuth (PIN flow, token refresh)
     schedule.py            # Schedule YAML loading, validation, sync
     comforts.py            # Comfort mode setpoint management
     status.py              # Live thermostat status extraction + formatting
+    history.py             # Room-sensor temp + occupancy history (climate-history)
     thermostats.py         # Thermostat registry loader
   ambient/
     client.py              # Outdoor temp fetching via Ambient Weather API

--- a/climate/blueair/CLAUDE.md
+++ b/climate/blueair/CLAUDE.md
@@ -4,7 +4,7 @@ See @README.md for API reference, CLI commands, and device specifics.
 
 ## Library source
 
-Local clone at `~/github.com/technicalpickles/blueair_api/` for reference. Key files:
-- `src/blueair_api/device_aws.py`: device model, all set_* methods
-- `src/blueair_api/http_aws_blueair.py`: API endpoints, auth flow
-- `src/blueair_api/model_enum.py`: SKU-to-model mapping
+The `blueair-api` package is a pip dependency (pinned in `pyproject.toml`), installed into the venv at `.venv/lib/python3.12/site-packages/blueair_api/`. Key files for reference:
+- `device_aws.py`: device model, all set_* methods
+- `http_aws_blueair.py`: API endpoints, auth flow
+- `model_enum.py`: SKU-to-model mapping

--- a/climate/blueair/README.md
+++ b/climate/blueair/README.md
@@ -15,7 +15,7 @@ Credentials are stored in 1Password (vault: `picklehome`, item: `BlueAir`) and i
 ```
 just blueair status [--json]                           # all managed devices
 just blueair discover                                  # find devices, create purifiers.yaml
-just blueair auth                                      # credential setup guidance (1Password + .env)
+just blueair auth                                      # prompt for credentials + validate connectivity (prints 1Password/.env hint)
 just blueair set <property> <value>                    # set property on all managed devices
 just blueair-set "Device Name" <property> <value>      # set property on one device
 ```

--- a/garage/README.md
+++ b/garage/README.md
@@ -13,7 +13,7 @@ Garage door status and control via the Aladdin Connect smart garage door opener.
      "email[text]=YOUR_EMAIL" \
      "password=YOUR_PASSWORD"
    ```
-2. Run `just dotenv` to inject credentials into `.env`
+2. Run `just dotenv` to inject credentials into `.env` (the `Aladdin Connect` item's `email`/`password` fields map to `ALADDIN_EMAIL` / `ALADDIN_PASSWORD`, which the CLI reads from the environment; see `.env.template`)
 3. Authenticate: `just garage auth`
 
 ## Commands

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -40,8 +40,11 @@ service also has its own README with first-time setup and operations.
 | backup | Nightly restic backups of `/srv/data` (GFS retention, Postgres dump support) | [README](services/backup/README.md) |
 | obsidian-sync | Headless Obsidian Sync clients keeping vaults on-host for agent access | [README](services/obsidian-sync/README.md) |
 | brineworks-server | FastAPI PRM backend (contacts/interactions), Tailscale Services | [README](services/brineworks-server/README.md) |
+| brineworks-agent | Phone-reachable Claude Code + `bw` session (SSH+tmux over Tailscale) | [README](services/brineworks-agent/README.md) |
+| second-brain-agent | Phone-reachable Claude Code session with `pickled-knowledge` vault mounted | [README](services/second-brain-agent/README.md) |
 | taskchampion-sync | Self-hosted Taskwarrior sync server (client-side encryption) | [README](services/taskchampion-sync/README.md) |
 | github-actions-runner | Self-hosted GitHub Actions runner for the pirpg repo | [README](services/github-actions-runner/README.md) |
+| woodpecker | Self-hosted Woodpecker CI for private GitHub repos (Funnel ingress) | [README](services/woodpecker/README.md) |
 
 All services deploy the same way from the Mac: `just dotenv` to refresh secrets, then
 `just deploy-<service>`. See the registry for the shared file layout and the per-service

--- a/homelab/services/README.md
+++ b/homelab/services/README.md
@@ -22,8 +22,8 @@ Each service directory in `homelab/services/<name>/` contains:
 | `deploy.sh` | Called by `just deploy-<name>`, handles scp + compose up + systemd |
 | `.env.vars` | Which env vars this service needs (filtered from master `.env` by `scripts/service-env`) |
 | `Dockerfile` | Custom image build (if applicable) |
-| `<name>.service` | systemd unit (timer-based services only) |
-| `<name>.timer` | systemd timer (if applicable) |
+| `<name>.service` | systemd unit (every service has one; long-lived services run a `oneshot`+`RemainAfterExit` unit, timer-based ones a triggered unit) |
+| `<name>.timer` | systemd timer (timer-based services only: `backup`, `climate-auto-switch`) |
 
 On picklelab, services land at:
 
@@ -240,6 +240,28 @@ Unlike other services, this one has **no `compose.picklelab.yaml`**: it only eve
 Commands: `just deploy-github-runner`, `just github-runner-logs`, `just github-runner-status`
 
 See [github-actions-runner/README.md](github-actions-runner/README.md) for the auth model and re-bootstrap procedure.
+
+---
+
+### woodpecker
+
+Self-hosted Woodpecker CI (server + agent + tailscale Funnel sidecar) for private GitHub repos. Test-only pipelines today. The one webhook-driven service, so it owns the homelab's only deliberate public ingress.
+
+| | |
+|---|---|
+| **Purpose** | Self-hosted CI for private GitHub repos (consolidates onto one system) |
+| **Compose** | `/opt/homelab/homelab/services/woodpecker/` |
+| **Data** | `/srv/data/woodpecker/` (`server/` SQLite, `ts-state/` node identity) |
+| **Access** | `https://woodpecker.<tailnet>.ts.net` (public via **Tailscale Funnel** on the sidecar's node, not host `tailscaled`) |
+| **Env vars** | `WOODPECKER_GITHUB_CLIENT`, `WOODPECKER_GITHUB_SECRET`, `WOODPECKER_AGENT_SECRET`, `WOODPECKER_TS_AUTHKEY` |
+| **Backup** | Yes, nightly (`/srv/data/woodpecker` picked up by restic; mostly rebuildable, `ts-state` is the bit worth keeping) |
+| **Restart** | `restart: unless-stopped` |
+
+CI steps run on a **rootless `dockerd` as a dedicated `ci` user** (uid 2000), so a compromised step can't read root/`technicalpickles`-owned secrets. Funnel uses userspace mode (HTTP-only, zero-priv); needs a one-time host setup (rootless docker for `ci`) and a Tailscale ACL granting `funnel` to `tag:ci`.
+
+Commands: `just deploy-woodpecker`, `just woodpecker-logs`, `just woodpecker-status`
+
+See [woodpecker/README.md](woodpecker/README.md) for full setup and the OAuth/Funnel prerequisites.
 
 ---
 

--- a/homelab/services/woodpecker/README.md
+++ b/homelab/services/woodpecker/README.md
@@ -1,0 +1,100 @@
+# Woodpecker CI
+
+Self-hosted [Woodpecker CI](https://woodpecker-ci.org) serving private GitHub repos (test-only pipelines today: run the suite on push/PR, report the check back to GitHub). Consolidates CI that would otherwise need a second GitHub Actions runner.
+
+Unlike the polling [`github-actions-runner`](../github-actions-runner/README.md), Woodpecker is **webhook-driven**, so GitHub has to reach in. That's the one real cost: a single deliberate public ingress via **Tailscale Funnel**, attached to a dedicated CI tailnet node rather than picklelab's host identity.
+
+Design: [`docs/plans/2026-06-18-woodpecker-ci-design.md`](../../../docs/plans/2026-06-18-woodpecker-ci-design.md). Implementation: [`docs/plans/2026-06-18-woodpecker-ci-plan.md`](../../../docs/plans/2026-06-18-woodpecker-ci-plan.md).
+
+## Architecture
+
+```
+GitHub (webhooks + OAuth)
+        │  HTTPS public, via Tailscale Funnel on the sidecar's node identity
+        ▼
+  ts-woodpecker (tailscale sidecar, userspace, zero-priv)
+  hostname: woodpecker  →  woodpecker.tail2023b7.ts.net
+  Funnel :443 → 127.0.0.1:8000   (funnel.json, checked in)
+        │  shares netns
+        ├── woodpecker-server  (:8000 HTTP UI/API, :9000 gRPC)
+        └── woodpecker-agent   (DOCKER_HOST → rootless ci socket)
+                                        │ spawns step containers on the
+                                        ▼ ROOTLESS dockerd running as `ci`
+```
+
+Three containers share one network namespace (`network_mode: service:ts-woodpecker`):
+
+- **ts-woodpecker** — Tailscale sidecar in **userspace mode** (`TS_USERSPACE=true`: HTTP-only, no `NET_ADMIN`, no `/dev/net/tun`). Owns the `woodpecker` MagicDNS name and the Funnel. Funnel config is the checked-in [`funnel.json`](funnel.json) (`TS_SERVE_CONFIG`), proxying `:443 → 127.0.0.1:8000`.
+- **woodpecker-server** — UI/API on loopback `:8000` (only Funnel exposes it), gRPC `:9000` stays inside the netns. SQLite DB. Pinned to `:v3` (Woodpecker dropped `:latest` to prevent accidental major upgrades; `--pull always` gets patches/minors, never a major).
+- **woodpecker-agent** — runs as the `ci` uid, points at the rootless docker socket via `DOCKER_HOST`. `WOODPECKER_MAX_WORKFLOWS=2` so CI can't starve the home-automation containers on the Celeron J3455.
+
+### Agent isolation: rootless Docker as a dedicated `ci` user
+
+The agent spawns step containers, which needs Docker socket access. Mounting the root `docker.sock` would be host-root-equivalent (a compromised CI step could `-v /:/host` and read `/opt/homelab/.env`). Instead, a second **rootless** `dockerd` runs as a dedicated `ci` user that owns nothing sensitive: a step that bind-mounts `/` reads everything as `ci`'s uid, so root- and `technicalpickles`-owned files (including the mode-600 secret superset) are unreadable. No privileged container, and the persistent daemon keeps the image-layer cache.
+
+The Woodpecker stack itself runs on the normal root daemon; only the agent is *pointed at* the rootless socket. `compose.picklelab.yaml` bind-mounts `/run/user/2000/docker.sock` (the `ci` user's rootless socket) into the agent at `/rootless/docker.sock`. The agent mounts *only* that socket, never the root socket.
+
+## Prerequisites (one-time)
+
+1. **Host: rootless docker for the `ci` user** (uid 2000). Create the `ci` user, run `dockerd-rootless-setuptool.sh install` as `ci`, `loginctl enable-linger ci`, set up subuid/subgid maps. See [`homelab/plans/homelab_03_host_setup.md`](../../plans/homelab_03_host_setup.md). The deploy script pre-flight checks for `/run/user/2000/docker.sock` and fails loudly if it's missing.
+
+2. **Tailscale ACL**: grant the `funnel` nodeAttr to `tag:ci`, and define `tag:ci` with `technicalpickles` as tagOwner. Funnel runs inside the sidecar, so picklelab's own `:443` and identity stay untouched.
+
+3. **GitHub OAuth App** (an OAuth App, *not* a GitHub App — GitHub Apps mishandle Woodpecker's token refresh today):
+
+   | Field | Value |
+   |-------|-------|
+   | Application name | `Woodpecker CI` |
+   | Homepage URL | `https://woodpecker.tail2023b7.ts.net` |
+   | Authorization callback URL | `https://woodpecker.tail2023b7.ts.net/authorize` |
+
+4. **1Password item** `Woodpecker CI` in the `picklehome` vault, surfaced via `.env.template` → `just dotenv`:
+
+   | `.env` var | Source |
+   |------------|--------|
+   | `WOODPECKER_GITHUB_CLIENT` | OAuth App Client ID |
+   | `WOODPECKER_GITHUB_SECRET` | OAuth App Client Secret |
+   | `WOODPECKER_AGENT_SECRET` | `openssl rand -hex 32` |
+   | `WOODPECKER_TS_AUTHKEY` | Tailscale reusable `tag:ci` auth key |
+
+   Because Funnel makes the endpoint public, three server settings are security-bearing and baked into `compose.yaml`: `WOODPECKER_OPEN=false`, `WOODPECKER_REPO_OWNERS=technicalpickles`, `WOODPECKER_ADMIN=technicalpickles`.
+
+## First-time Setup
+
+```bash
+just dotenv             # pull the four Woodpecker secrets from 1Password
+just deploy-woodpecker
+```
+
+`deploy.sh` is idempotent (safe on first setup or any redeploy): it checks the rootless socket, creates `/srv/data/woodpecker/{ts-state,server}` (chowning `server/` to uid 1000 so the non-root server image can create its SQLite DB), pulls images, links + enables the systemd unit, restarts, then health-checks `http://127.0.0.1:8000/healthz` from inside the sidecar netns.
+
+If the Funnel hostname doesn't resolve yet, check `docker compose exec ts-woodpecker tailscale funnel status`. Because `TS_STATE_DIR` is persisted to `/srv/data/woodpecker/ts-state`, the `woodpecker` name survives recreates instead of dedup'ing to `woodpecker-1`.
+
+Per-repo CI is a checked-in `.woodpecker.yml` in each target repo plus enabling the repo in the Woodpecker UI (auto-creates the webhook).
+
+## Deploying Updates
+
+```bash
+just deploy-woodpecker
+```
+
+## Status & Logs
+
+```bash
+just woodpecker-status   # systemd unit + docker compose ps
+just woodpecker-logs     # follow server + agent logs (last 100 lines)
+```
+
+## Data Locations (on picklelab)
+
+```
+/opt/homelab/homelab/services/woodpecker/   # service files (git-managed)
+/srv/data/woodpecker/ts-state/              # tailscale node identity (persisted, backed up)
+/srv/data/woodpecker/server/                # SQLite DB (uid 1000, backed up nightly)
+```
+
+## Backup
+
+State lands under `/srv/data/woodpecker/`, already swept by the nightly restic job. Most of it is rebuildable (build history is disposable, repo activations re-create webhooks, pipeline secrets duplicate 1Password). The bit worth persisting is `ts-state/` (the node identity), which keeps the `woodpecker` hostname across a rebuild.
+
+Sharp edge: restic snapshots SQLite live, so a backup taken mid-write could be torn. For a test-only CI DB written a few times a day the risk is tiny and the data is rebuildable. No pre-backup SQLite dump for now.

--- a/lighting/README.md
+++ b/lighting/README.md
@@ -78,4 +78,5 @@ lighting/
   caseta.py            # Caseta device commands (devices, status, on, off, set)
   hue_cli.py           # Hue CLI entry point
   hue.py               # Hue bridge connection + all Hue commands
+  .certs/              # Lutron Caseta TLS client cert, key, and CA (from pairing)
 ```

--- a/network/CLAUDE.md
+++ b/network/CLAUDE.md
@@ -37,6 +37,7 @@ Uses `requests` for status pages, `playwright` for diag commands (which stream o
 ```bash
 just bgw fiber               # fiber signal / optical metrics
 just bgw broadband           # WAN connection status
+just bgw wifi                # BGW WiFi radio status (both bands)
 just bgw trace <ip>          # traceroute from BGW WAN
 just bgw ping <ip>           # ping from BGW WAN
 just bgw nslookup <host>
@@ -51,6 +52,22 @@ Visits a URL with a headless browser and reports per-hostname request stats (lat
 ```bash
 just network-profile https://example.com
 just network-profile https://example.com --slow-ms 1000 --timeout 15
+```
+
+### `snapshot.py`: full point-in-time network snapshot
+
+Captures BGW fiber + broadband, USG WAN, DNS, and traceroute in one shot.
+
+```bash
+just network-snapshot
+```
+
+### `resolve.py`: DNS resolution comparison
+
+Compares DNS resolution across Cloudflare, Google, BGW, and USG resolvers for a host.
+
+```bash
+just network-resolve <host>
 ```
 
 ### `isp_status.py`: ISP and CDN status checker
@@ -122,7 +139,7 @@ just unifi devices                        # all adopted devices with firmware ve
 just unifi topology                       # live device tree with uplink ports + radio state
 just unifi topology --format mermaid      # mermaid diagram for docs
 just unifi topology --format dot          # graphviz DOT
-just unifi rename <device> <new-name>     # rename a device
+just unifi rename <client> <new-name>     # set a friendly alias for a client device (by hostname/IP/MAC)
 
 # USG / gateway
 just unifi usg stats                      # USG CPU, memory, uplink rates

--- a/network/README.md
+++ b/network/README.md
@@ -43,4 +43,4 @@ Scripts that talk to the CloudKey or Cloudflare require `.env` (generated via `j
 
 - `UNIFI_API_KEY`: UniFi CloudKey API key (Network → Integrations)
 - `CLOUDFLARE_RADAR_API_TOKEN`: Cloudflare dashboard → My Profile → API Tokens → `Account > Radar: Read`
-- `UNIFI_ADMIN_USERNAME` / `UNIFI_ADMIN_PASSWORD`: only needed for `just unifi usg dns` (SSH)
+- `UNIFI_ADMIN_USERNAME` / `UNIFI_ADMIN_PASSWORD`: needed for the SSH-based `just unifi usg dns` and `just unifi usg resolve`


### PR DESCRIPTION
A cross-repo documentation accuracy pass. Five parallel audits compared every doc claim (just commands, file paths, module layouts, service registries) against the actual code. Most docs were accurate; the real gaps clustered in the homelab service registries.

## Registry gaps (the big ones)
- **Root `CLAUDE.md` Homelab Services table** listed 5 of 9 services. Added `climate-auto-switch`, `backup`, `github-actions-runner`, `woodpecker`. Same fix to the "Key services" Directories bullet.
- **`homelab/README.md`** table listed 6 of 9. Added `brineworks-agent`, `second-brain-agent`, `woodpecker`.
- **`homelab/services/README.md`** was missing the `woodpecker` entry.
- **New `homelab/services/woodpecker/README.md`** — `woodpecker` was fully deployed (service dir + 6 files + 3 Justfile tasks) with zero documentation. Written from the compose files, deploy.sh, and the design doc.

## Wrong facts
- `homelab/services/README.md`: `.service` is not "timer-based only" (every service has one; only `backup` + `climate-auto-switch` have timers).
- `network/CLAUDE.md`: mtr path `network-diag-results/` → `network/diag-results/`; `unifi rename` sets a client alias, not a device name.
- `network/README.md`: `UNIFI_ADMIN_*` creds also needed for `usg resolve`.
- `climate/blueair/CLAUDE.md`: library is a pip dep in `.venv`, not a (nonexistent) local clone.

## Incomplete / stale
- `network/CLAUDE.md`: documented `snapshot.py`, `resolve.py`, and `bgw wifi`.
- `climate/README.md`: added `runlog.py` + `ecobee/history.py`; fixed `sync.py` invocation note.
- `lighting/README.md`: added `.certs/` to module structure.
- `garage/README.md`: named `ALADDIN_EMAIL`/`ALADDIN_PASSWORD` env vars.
- `climate/blueair/README.md`: `auth` prompts + validates connectivity.
- Root `CLAUDE.md` Directories: added `_bmad/`, `_bmad-output/`, broadened `docs/`.

Verified clean (no changes needed): `locks/`, `sonos/`, `docs/CONVENTIONS.md`, root `README.md`, `climate/CLAUDE.md`, integrations table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)