### PR TITLE
fix: grant second-brain-agent write access to the vault

### DIFF
--- a/homelab/services/CLAUDE.md
+++ b/homelab/services/CLAUDE.md
@@ -1,0 +1,19 @@
+@README.md
+
+## When adding a new service with bind mounts
+
+Before writing any compose or Dockerfile, answer:
+
+1. **What uid will the process run as?** Check the base image's default (many images default to root). If it needs to write to `/srv/data/`, it must not run as root.
+2. **Does any other service read or write the same host path?** If yes, both must use the same uid. Set `user: "uid:gid"` in compose for both.
+3. **Do existing host files have the right ownership?** Add `sudo chown -R uid:gid /srv/data/<service>` to `deploy.sh` (after `mkdir -p`, before `docker compose up`).
+
+For the implementation choices, see the "Container user model and bind-mount ownership" section in README.md — it covers `user:` vs Dockerfile, explicit uid vs named user, and the cross-service sharing pattern.
+
+## When changing a service's uid
+
+If an existing service gains a new `user:` or changes uid:
+
+1. Update `deploy.sh` to chown the data directory to the new uid — this runs on next deploy and fixes existing files
+2. If another service shares a volume with this one, update that service's deploy.sh too
+3. If the container writes the mount at startup (entrypoint), gate any recovery chown on `stat -c %u` rather than running unconditionally

--- a/homelab/services/README.md
+++ b/homelab/services/README.md
@@ -35,6 +35,38 @@ TLS and external access use **Tailscale Services**: `tailscaled` on the host ter
 
 Per-service hostname is stored in 1Password as `<SERVICE>_HOST` and pulled into `.env`. The tailnet suffix is documented in the project [CLAUDE.md](../../CLAUDE.md).
 
+### Container user model and bind-mount ownership
+
+Containers that write to `/srv/data/<service>/` bind mounts run as a **non-root user whose uid matches the host file ownership**. This is the invariant that makes volume sharing work: Linux bind mounts expose the host inode ownership directly, so a container process can only write if its uid owns (or has group write on) the files.
+
+**How each piece enforces this:**
+
+| Where | What it does |
+|-------|--------------|
+| `compose.yaml` `user: "uid:gid"` | Sets the process uid inside the container. Use explicit `"uid:gid"` string (e.g. `"1000:1000"`), not a named user — named users couple the compose file to the image's internal `/etc/passwd`. |
+| `deploy.sh` `chown -R uid:gid /srv/data/<service>` | Fixes existing host files before the container restarts with a new uid. Pattern: chown immediately after `mkdir -p`, before `docker compose up`. |
+| Dockerfile `ARG USER_UID` / `useradd` | Custom images (second-brain-agent, brineworks-agent) create the user inside the image at the same uid. Required when the container process needs a real login shell, home directory, or sshd. Off-the-shelf images (obsidian-sync, woodpecker) use `user:` in compose instead — no Dockerfile change needed. |
+
+**Current uid assignments:**
+
+| Service | uid:gid | Set via |
+|---------|---------|---------|
+| second-brain-agent | 1000:1000 | Dockerfile `ARG USER_UID` + `compose.yaml` (implicit, Dockerfile sets it) |
+| brineworks-agent | 1000:1000 | Dockerfile in brineworks repo |
+| obsidian-sync (all vaults) | 1000:1000 | `compose.yaml` `user: "1000:1000"` |
+| woodpecker-server | 1000:1000 | Image default (woodpecker v3 ships uid 1000); `deploy.sh` chowns `/srv/data/woodpecker/server` |
+| woodpecker-agent | 2000:2000 | `compose.yaml` `user: "2000:2000"`; matches the `ci` system user that owns the rootless docker socket |
+| climate-auto-switch | root | No volume sharing; no write-access risk |
+| backup | `backup` system user | Systemd service user; uses `setfacl` for read access to other services' files |
+
+**Cross-service volume sharing** requires uid alignment at both ends:
+- **Producer** (the writer): set `user: "uid:gid"` in compose
+- **Consumer** (the reader/writer): set `user:` or build with matching uid in Dockerfile
+- **deploy.sh**: chown the shared path to the common uid as part of both services' deploy scripts
+- **Transition recovery**: if an entrypoint needs to chown a bind mount (e.g. files existed as root before the uid fix), gate it on a fast check (`stat -c %u`) so it doesn't recurse on every start once ownership is already correct
+
+Current cross-service share: obsidian-sync → second-brain-agent (both uid 1000, `/srv/data/obsidian-sync/vaults/pickled-knowledge`).
+
 ### When the default doesn't fit: container-as-node (UDP, native node identity)
 
 Tailscale Services (host `tailscaled` + serve) is **TCP/HTTP only**. A service that needs **UDP** (e.g. mosh, WireGuard, game/voice protocols) or wants its own first-class tailnet identity cannot use the serve proxy: UDP aimed at a serve-proxied hostname has nowhere to land.

--- a/homelab/services/obsidian-sync/README.md
+++ b/homelab/services/obsidian-sync/README.md
@@ -12,10 +12,9 @@ long-lived container continuously syncing against Obsidian's cloud.
   `pickled-knowledge`, each with two volumes:
   - config: Obsidian config + sync credentials (per-vault, so logins don't collide)
   - `/vault`: the synced vault files
-- **User model:** `pickled-knowledge` runs as uid 1000 (`user: "1000:1000"`) so the
-  second-brain-agent container (also uid 1000) can write vault files. Config mounts at
-  `/home/node/.config`. `rpg` runs as root (config at `/root/.config`) since it isn't
-  shared with any other service.
+- **User model:** all vault containers run as uid 1000 (`user: "1000:1000"`), with config
+  at `/home/node/.config`. This lets the second-brain-agent container (also uid 1000) write
+  to the pickled-knowledge vault.
 - **On-host data:** `compose.picklelab.yaml` maps those volumes to
   `/srv/data/obsidian-sync/config/<vault>` and `/srv/data/obsidian-sync/vaults/<vault>`.
 - **Service unit:** `obsidian-sync.service` is a `RemainAfterExit` oneshot that does
@@ -57,10 +56,8 @@ just deploy-obsidian-sync                        # redeploy (git pull + rebuild 
 
 ## Adding a vault
 
-1. Add a new service block (and its two volumes) to `compose.yaml`
-   - If the vault will be shared with another container (e.g. an agent), add `user: "1000:1000"`
-     and mount config at `/home/node/.config` instead of `/root/.config`
+1. Add a new service block (and its two volumes) to `compose.yaml`, following the `rpg` pattern:
+   `user: "1000:1000"`, config at `/home/node/.config`
 2. Add the on-host volume mounts to `compose.picklelab.yaml`
-3. Add the data dirs to the `mkdir -p` list in `deploy.sh`; if running as uid 1000, also add
-   a `chown -R 1000:1000` for that vault's config and vault dirs
+3. Add the data dirs to the `mkdir -p` and `chown -R 1000:1000` blocks in `deploy.sh`
 4. `just deploy-obsidian-sync`, then `just obsidian-sync-exec <vault> login` + `sync-setup`

--- a/homelab/services/obsidian-sync/README.md
+++ b/homelab/services/obsidian-sync/README.md
@@ -10,9 +10,12 @@ long-lived container continuously syncing against Obsidian's cloud.
   installed globally; the container runs `ob sync --continuous`.
 - **One container per vault.** `compose.yaml` defines two services, `rpg` and
   `pickled-knowledge`, each with two volumes:
-  - `/root/.config`: the vault's Obsidian config + sync credentials (per-vault, so logins
-    don't collide)
+  - config: Obsidian config + sync credentials (per-vault, so logins don't collide)
   - `/vault`: the synced vault files
+- **User model:** `pickled-knowledge` runs as uid 1000 (`user: "1000:1000"`) so the
+  second-brain-agent container (also uid 1000) can write vault files. Config mounts at
+  `/home/node/.config`. `rpg` runs as root (config at `/root/.config`) since it isn't
+  shared with any other service.
 - **On-host data:** `compose.picklelab.yaml` maps those volumes to
   `/srv/data/obsidian-sync/config/<vault>` and `/srv/data/obsidian-sync/vaults/<vault>`.
 - **Service unit:** `obsidian-sync.service` is a `RemainAfterExit` oneshot that does
@@ -55,6 +58,9 @@ just deploy-obsidian-sync                        # redeploy (git pull + rebuild 
 ## Adding a vault
 
 1. Add a new service block (and its two volumes) to `compose.yaml`
+   - If the vault will be shared with another container (e.g. an agent), add `user: "1000:1000"`
+     and mount config at `/home/node/.config` instead of `/root/.config`
 2. Add the on-host volume mounts to `compose.picklelab.yaml`
-3. Add the data dirs to the `mkdir -p` list in `deploy.sh`
+3. Add the data dirs to the `mkdir -p` list in `deploy.sh`; if running as uid 1000, also add
+   a `chown -R 1000:1000` for that vault's config and vault dirs
 4. `just deploy-obsidian-sync`, then `just obsidian-sync-exec <vault> login` + `sync-setup`

--- a/homelab/services/obsidian-sync/compose.picklelab.yaml
+++ b/homelab/services/obsidian-sync/compose.picklelab.yaml
@@ -6,5 +6,5 @@ services:
 
   pickled-knowledge:
     volumes:
-      - /srv/data/obsidian-sync/config/pickled-knowledge:/root/.config
+      - /srv/data/obsidian-sync/config/pickled-knowledge:/home/node/.config
       - /srv/data/obsidian-sync/vaults/pickled-knowledge:/vault

--- a/homelab/services/obsidian-sync/compose.picklelab.yaml
+++ b/homelab/services/obsidian-sync/compose.picklelab.yaml
@@ -1,7 +1,7 @@
 services:
   rpg:
     volumes:
-      - /srv/data/obsidian-sync/config/rpg:/root/.config
+      - /srv/data/obsidian-sync/config/rpg:/home/node/.config
       - /srv/data/obsidian-sync/vaults/rpg:/vault
 
   pickled-knowledge:

--- a/homelab/services/obsidian-sync/compose.yaml
+++ b/homelab/services/obsidian-sync/compose.yaml
@@ -10,10 +10,13 @@ services:
 
   pickled-knowledge:
     image: obsidian-sync
+    # Run as the node user (uid=1000) so vault files are owned by uid 1000,
+    # matching the second-brain-agent container's technicalpickles user.
+    user: "node"
     init: true
     restart: unless-stopped
     volumes:
-      - ob-config-pickled-knowledge:/root/.config
+      - ob-config-pickled-knowledge:/home/node/.config
       - pickled-knowledge:/vault
 
 volumes:

--- a/homelab/services/obsidian-sync/compose.yaml
+++ b/homelab/services/obsidian-sync/compose.yaml
@@ -4,15 +4,18 @@ services:
     build: .
     init: true
     restart: unless-stopped
+    # rpg vault is not shared with any other service; running as root is fine.
     volumes:
       - ob-config-rpg:/root/.config
       - rpg:/vault
 
   pickled-knowledge:
     image: obsidian-sync
-    # Run as the node user (uid=1000) so vault files are owned by uid 1000,
-    # matching the second-brain-agent container's technicalpickles user.
-    user: "node"
+    # Run as uid 1000 so vault files are owned by uid 1000, matching the
+    # second-brain-agent container's technicalpickles user. Uses explicit
+    # uid:gid rather than the named "node" user to avoid coupling to the
+    # image's internal user table.
+    user: "1000:1000"
     init: true
     restart: unless-stopped
     volumes:

--- a/homelab/services/obsidian-sync/compose.yaml
+++ b/homelab/services/obsidian-sync/compose.yaml
@@ -2,19 +2,15 @@ services:
   rpg:
     image: obsidian-sync
     build: .
+    user: "1000:1000"
     init: true
     restart: unless-stopped
-    # rpg vault is not shared with any other service; running as root is fine.
     volumes:
-      - ob-config-rpg:/root/.config
+      - ob-config-rpg:/home/node/.config
       - rpg:/vault
 
   pickled-knowledge:
     image: obsidian-sync
-    # Run as uid 1000 so vault files are owned by uid 1000, matching the
-    # second-brain-agent container's technicalpickles user. Uses explicit
-    # uid:gid rather than the named "node" user to avoid coupling to the
-    # image's internal user table.
     user: "1000:1000"
     init: true
     restart: unless-stopped

--- a/homelab/services/obsidian-sync/deploy.sh
+++ b/homelab/services/obsidian-sync/deploy.sh
@@ -19,6 +19,11 @@ sudo mkdir -p \
     "$DATA_DIR/vaults/rpg" \
     "$DATA_DIR/vaults/pickled-knowledge"
 
+echo "==> Fixing ownership: pickled-knowledge vault and config → uid 1000 (node user)"
+sudo chown -R 1000:1000 \
+    "$DATA_DIR/config/pickled-knowledge" \
+    "$DATA_DIR/vaults/pickled-knowledge"
+
 echo "==> Building image"
 cd "$SERVICE_DIR"
 docker compose -f compose.yaml -f compose.picklelab.yaml build

--- a/homelab/services/obsidian-sync/deploy.sh
+++ b/homelab/services/obsidian-sync/deploy.sh
@@ -19,9 +19,11 @@ sudo mkdir -p \
     "$DATA_DIR/vaults/rpg" \
     "$DATA_DIR/vaults/pickled-knowledge"
 
-echo "==> Fixing ownership: pickled-knowledge vault and config → uid 1000 (node user)"
+echo "==> Fixing ownership: all vaults and configs → uid 1000"
 sudo chown -R 1000:1000 \
+    "$DATA_DIR/config/rpg" \
     "$DATA_DIR/config/pickled-knowledge" \
+    "$DATA_DIR/vaults/rpg" \
     "$DATA_DIR/vaults/pickled-knowledge"
 
 echo "==> Building image"

--- a/homelab/services/second-brain-agent/entrypoint.sh
+++ b/homelab/services/second-brain-agent/entrypoint.sh
@@ -41,9 +41,14 @@ ln -sf /data/claude.json "$HOME_DIR/.claude.json"
 # Ensure home dir ownership is correct
 chown "$USERNAME:$USERNAME" "$HOME_DIR"
 
-# Fix vault ownership: obsidian-sync may have created files as root before the
-# user: "node" fix was deployed. Safe to run on every start — fast, idempotent.
-chown -R "$USERNAME:$USERNAME" "${VAULT_DIR:-/vault}"
+# Transition-period recovery: chown the vault if obsidian-sync created files as
+# root before the user: "1000:1000" fix was deployed. Checks only the vault root
+# (fast) to avoid recursing on every start once ownership is correct.
+# TODO: remove once picklelab has been running obsidian-sync at uid 1000 long
+# enough that no root-owned vault files remain.
+if [ "$(stat -c %u "${VAULT_DIR:-/vault}")" != "1000" ]; then
+  chown -R "$USERNAME:$USERNAME" "${VAULT_DIR:-/vault}"
+fi
 
 # Start a detached `main` tmux session as the user, rooted in the vault, so there's
 # always a session to attach to (continuum auto-restores into it from /data). The

--- a/homelab/services/second-brain-agent/entrypoint.sh
+++ b/homelab/services/second-brain-agent/entrypoint.sh
@@ -41,6 +41,10 @@ ln -sf /data/claude.json "$HOME_DIR/.claude.json"
 # Ensure home dir ownership is correct
 chown "$USERNAME:$USERNAME" "$HOME_DIR"
 
+# Fix vault ownership: obsidian-sync may have created files as root before the
+# user: "node" fix was deployed. Safe to run on every start — fast, idempotent.
+chown -R "$USERNAME:$USERNAME" "${VAULT_DIR:-/vault}"
+
 # Start a detached `main` tmux session as the user, rooted in the vault, so there's
 # always a session to attach to (continuum auto-restores into it from /data). The
 # zz-tmux-autoattach.sh profile.d hook lands interactive logins straight here.


### PR DESCRIPTION
obsidian-sync ran as root, creating vault files owned by root:root. The
second-brain-agent's technicalpickles user (uid=1000) could read but not
write them.

- Run obsidian-sync's pickled-knowledge service as user: "node" (uid=1000,
  pre-exists in node:22-alpine) so new synced files are owned by uid 1000
- Update config mount path from /root/.config → /home/node/.config to match
  the node user's home directory
- deploy.sh: chown existing host files to 1000:1000 on next deploy
- second-brain-agent entrypoint: chown vault at startup as belt-and-suspenders
  for any files created before this fix lands

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SuEWXJ3jDQ9Zmhiw7fDJg5