### PR TITLE
fix(just): stop obsidian-sync-exec from eating ob args as the host

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,11 @@
 set dotenv-load
 set positional-arguments
 
+# Default target host for recipes that can't take `host` as a parameter because
+# they end in variadic `*ARGS` (positional binding would eat the first ob arg as
+# the host). Override per-call with `just host=otherhost <recipe> ...`.
+host := "picklelab"
+
 # First-time setup: PIN flow + thermostat discovery
 climate-auth:
     uv run python -m climate.sync auth
@@ -478,7 +483,7 @@ deploy-obsidian-sync host="picklelab":
     ssh {{host}} "cd /opt/homelab && git pull && homelab/services/obsidian-sync/deploy.sh"
 
 # Run ob CLI against a specific vault's container (e.g. "rpg sync-status")
-obsidian-sync-exec vault host="picklelab" *ARGS:
+obsidian-sync-exec vault *ARGS:
     ssh -t {{host}} "docker exec -it obsidian-sync-{{vault}}-1 ob {{ARGS}}"
 
 # Tail Obsidian Sync container logs from picklelab


### PR DESCRIPTION
## What

`just obsidian-sync-exec rpg sync-status` (the form documented in `homelab/services/obsidian-sync/README.md`) failed with:

```
ssh: connect to host sync-status port 22: Operation timed out
```

## Why

The recipe was:

```just
obsidian-sync-exec vault host="picklelab" *ARGS:
    ssh -t {{host}} "docker exec -it obsidian-sync-{{vault}}-1 ob {{ARGS}}"
```

just binds positional args left-to-right, and `host` sits between `vault` and the variadic `*ARGS`. So `just obsidian-sync-exec pickled-knowledge sync-status` bound `sync-status` to `host` (not ARGS) and tried to SSH to a host named `sync-status`. This recipe is the only one in the Justfile with a variadic after a defaulted `host`, so it's the only one affected.

## Fix

Move `host` to a top-level justfile variable. The documented two-arg usage now works, and the host is still overridable per-call:

```bash
just obsidian-sync-exec pickled-knowledge sync-status      # default host=picklelab
just host=otherhost obsidian-sync-exec rpg login           # override
```

## Validation

Dry-ran all three forms (default, multi-word ARGS, host override) and confirmed the rendered `ssh` command is correct. Ran live against picklelab: `just obsidian-sync-exec pickled-knowledge sync-status` and `... rpg sync-status` both return sync config now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)