### PR TITLE
feat(climate): scope weather + air quality by location

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,13 @@ HOME_LON={{ op://picklehome/Home/longitude }}
 # Ambient Weather stations (comma-separated MACs, 1Password item: picklehome/Ambient Weather Stations)
 AMBIENT_STATION_MACS={{ op://picklehome/Ambient Weather Stations/station_macs }}
 
+# Named locations (main house, beachhouse, ...) for weather + air-quality commands.
+# PICKLEHOME_LOCATIONS is NOT set here: `just dotenv` generates it by discovering
+# every 1Password item tagged `picklehome-location`. Each such item needs fields:
+#   slug, label, latitude, longitude, station_macs (comma-separated)
+# HOME_LAT/HOME_LON/AMBIENT_STATION_MACS above are the legacy single-home fallback
+# used when no tagged items exist. See climate/README.md and scripts/locations-filter.jq.
+
 # Ecobee thermostat API (1Password item: Ecobee)
 ECOBEE_API_KEY={{ op://picklehome/Ecobee/api_key }}
 

--- a/Justfile
+++ b/Justfile
@@ -54,9 +54,13 @@ climate-weather-discover *ARGS:
 climate-weather *ARGS:
     uv run python -m climate.sync weather {{ARGS}}
 
+# List configured locations (main house, beachhouse, ...)
+climate-locations *ARGS:
+    uv run python -m climate.sync locations {{ARGS}}
+
 # Show current outdoor air quality and pollen
-climate-air-quality:
-    uv run python -m climate.sync air-quality
+climate-air-quality *ARGS:
+    uv run python -m climate.sync air-quality {{ARGS}}
 
 # Switch schedule comfort mode: heat | cool | auto
 climate-comfort-switch MODE *ARGS:

--- a/climate/README.md
+++ b/climate/README.md
@@ -31,7 +31,9 @@ Station MACs are sensitive (geolocatable), stored in 1Password, injected via `.e
 
 Weather and air-quality commands are scoped by location (Atlanta main house, MA beachhouse, ...) and cover **all** configured locations by default, grouped in the output. Pass `--location <slug>` to limit to one.
 
-Each location is a 1Password item tagged `picklehome-location` with fields: `slug`, `label`, `latitude`, `longitude`, `station_macs` (comma-separated). `just dotenv` discovers every tagged item and snapshots them into the `PICKLEHOME_LOCATIONS` JSON var in `.env` (via `scripts/locations-filter.jq`); `climate/locations.py` parses it at runtime. Add or edit an address in 1Password, then re-run `just dotenv` to pick it up.
+Each location is a 1Password item tagged `picklehome-location` with fields: `slug`, `label`, `latitude`, `longitude`, `station_macs` (comma-separated), and optional `comfort_mode` (`true` for a location whose thermostat this tooling manages). `just dotenv` discovers every tagged item and snapshots them into the `PICKLEHOME_LOCATIONS` JSON var in `.env` (via `scripts/locations-filter.jq`); `climate/locations.py` parses it at runtime. Add or edit an address in 1Password, then re-run `just dotenv` to pick it up.
+
+Only `comfort_mode` locations get the Ecobee comfort-mode recommendation in `just climate-weather` (the main house); weather-only locations like the beachhouse show outdoor temp alone. Comfort switching itself (`just climate-comfort-switch`) remains main-house-only.
 
 Coords and MACs are geolocatable, so they live only in the generated `.env`, never a checked-in file. When no tagged items exist, the commands fall back to the legacy single-home `HOME_LAT` / `HOME_LON` / `AMBIENT_STATION_MACS` vars. Run `just climate-locations` to see what's configured.
 

--- a/climate/README.md
+++ b/climate/README.md
@@ -27,6 +27,14 @@ Pairing alone doesn't change any temperatures. See the Ecobee API notes below fo
 
 Station MACs are sensitive (geolocatable), stored in 1Password, injected via `.env`. See `.env.template` for the `AMBIENT_STATION_MACS` variable.
 
+### Locations (multi-address)
+
+Weather and air-quality commands are scoped by location (Atlanta main house, MA beachhouse, ...) and cover **all** configured locations by default, grouped in the output. Pass `--location <slug>` to limit to one.
+
+Each location is a 1Password item tagged `picklehome-location` with fields: `slug`, `label`, `latitude`, `longitude`, `station_macs` (comma-separated). `just dotenv` discovers every tagged item and snapshots them into the `PICKLEHOME_LOCATIONS` JSON var in `.env` (via `scripts/locations-filter.jq`); `climate/locations.py` parses it at runtime. Add or edit an address in 1Password, then re-run `just dotenv` to pick it up.
+
+Coords and MACs are geolocatable, so they live only in the generated `.env`, never a checked-in file. When no tagged items exist, the commands fall back to the legacy single-home `HOME_LAT` / `HOME_LON` / `AMBIENT_STATION_MACS` vars. Run `just climate-locations` to see what's configured.
+
 ### BlueAir purifiers
 
 See [blueair/README.md](blueair/README.md).
@@ -37,7 +45,7 @@ Uses the Google Air Quality and Pollen APIs.
 
 1. Enable the Air Quality API and Pollen API in the [Google Cloud console](https://console.cloud.google.com)
 2. Store the key in 1Password (`Google Air Quality API` item, `api_key` field) and run `just dotenv`; it lands in `.env` as `GOOGLE_POLLEN_API_KEY` (one key covers both APIs)
-3. The lookup uses your home coordinates from `HOME_LAT` / `HOME_LON` (also in `.env`, sourced from the `Home` 1Password item)
+3. The lookup runs per location (see [Locations](#locations-multi-address)); with no tagged locations it falls back to `HOME_LAT` / `HOME_LON`
 
 ## Commands
 
@@ -57,14 +65,15 @@ just climate-comfort-switch heat|cool|auto [--dry-run] [--clear-holds]  # season
 ### Weather
 
 ```
-just climate-weather                     # outdoor temp + comfort mode recommendation
-just climate-weather-discover            # find nearby Ambient Weather stations
+just climate-locations                          # list configured locations (main house, beachhouse, ...)
+just climate-weather [--location SLUG]           # outdoor temp + comfort mode recommendation
+just climate-weather-discover [--location SLUG]  # find nearby Ambient Weather stations
 ```
 
 ### Air quality
 
 ```
-just climate-air-quality                 # current AQI, dominant pollutant, health rec + pollen forecast
+just climate-air-quality [--location SLUG]       # current AQI, dominant pollutant, health rec + pollen forecast
 ```
 
 ### BlueAir

--- a/climate/locations.py
+++ b/climate/locations.py
@@ -24,6 +24,10 @@ class Location:
     lat: float
     lon: float
     station_macs: list[str] = field(default_factory=list)
+    # Whether this location has a thermostat this tooling manages (Atlanta does,
+    # the beachhouse doesn't). Gates the comfort-mode recommendation in
+    # `just climate-weather`, which is Ecobee-specific (smart1/smart2).
+    comfort_mode: bool = False
 
 
 def load_locations() -> list[Location]:
@@ -55,7 +59,9 @@ def load_locations() -> list[Location]:
                 f"HOME_LAT/HOME_LON are not valid floats: {lat_str!r}, {lon_str!r}"
             ) from e
         macs = _split_macs(os.environ.get("AMBIENT_STATION_MACS", ""))
-        return [Location(slug="home", label="Home", lat=lat, lon=lon, station_macs=macs)]
+        # Legacy single-home == the Atlanta thermostat setup, so it manages comfort.
+        return [Location(slug="home", label="Home", lat=lat, lon=lon,
+                         station_macs=macs, comfort_mode=True)]
 
     return []
 
@@ -89,6 +95,7 @@ def _from_dict(d: dict) -> Location:
         lat=float(d["lat"]),
         lon=float(d["lon"]),
         station_macs=list(d.get("station_macs", [])),
+        comfort_mode=bool(d.get("comfort_mode", False)),
     )
 
 

--- a/climate/locations.py
+++ b/climate/locations.py
@@ -1,0 +1,96 @@
+"""Named locations (Atlanta main house, MA beachhouse, ...).
+
+Locations are discovered from 1Password at `just dotenv` time: every item tagged
+`picklehome-location` is read and its fields snapshotted into the
+PICKLEHOME_LOCATIONS env var as a JSON array (see scripts/dotenv). This module
+parses that var at runtime; it never calls `op` itself.
+
+Coords and station MACs are geolocatable, so they live only in .env (gitignored),
+never a checked-in config file.
+
+Falls back to the legacy single-home HOME_LAT/HOME_LON/AMBIENT_STATION_MACS vars
+so weather and air-quality commands work before any tagged items exist.
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Location:
+    slug: str
+    label: str
+    lat: float
+    lon: float
+    station_macs: list[str] = field(default_factory=list)
+
+
+def load_locations() -> list[Location]:
+    """Parse PICKLEHOME_LOCATIONS, or synthesize one home from legacy env vars.
+
+    Returns an empty list only when nothing at all is configured; callers that
+    need at least one location should use resolve_locations() instead.
+    """
+    raw = os.environ.get("PICKLEHOME_LOCATIONS", "").strip()
+    if raw:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"PICKLEHOME_LOCATIONS is not valid JSON: {e}. Re-run 'just dotenv'."
+            ) from e
+        locations = [_from_dict(d) for d in data]
+        if locations:
+            return locations
+
+    # Legacy fallback: synthesize a single "home" from the original env vars.
+    lat_str = os.environ.get("HOME_LAT", "")
+    lon_str = os.environ.get("HOME_LON", "")
+    if lat_str and lon_str:
+        try:
+            lat, lon = float(lat_str), float(lon_str)
+        except ValueError as e:
+            raise RuntimeError(
+                f"HOME_LAT/HOME_LON are not valid floats: {lat_str!r}, {lon_str!r}"
+            ) from e
+        macs = _split_macs(os.environ.get("AMBIENT_STATION_MACS", ""))
+        return [Location(slug="home", label="Home", lat=lat, lon=lon, station_macs=macs)]
+
+    return []
+
+
+def resolve_locations(slug: str | None = None) -> list[Location]:
+    """All configured locations, or just the one matching `slug`.
+
+    Raises RuntimeError (caught at the command boundary) when nothing is
+    configured or the requested slug is unknown, rather than returning an empty
+    list the caller has to second-guess.
+    """
+    locations = load_locations()
+    if not locations:
+        raise RuntimeError(
+            "No locations configured. Set HOME_LAT/HOME_LON, or tag 1Password "
+            "items with 'picklehome-location', then run 'just dotenv'."
+        )
+    if slug is None:
+        return locations
+    matches = [loc for loc in locations if loc.slug.lower() == slug.lower()]
+    if not matches:
+        available = ", ".join(loc.slug for loc in locations)
+        raise RuntimeError(f"Unknown location {slug!r}. Available: {available}")
+    return matches
+
+
+def _from_dict(d: dict) -> Location:
+    return Location(
+        slug=d["slug"],
+        label=d.get("label") or d["slug"],
+        lat=float(d["lat"]),
+        lon=float(d["lon"]),
+        station_macs=list(d.get("station_macs", [])),
+    )
+
+
+def _split_macs(raw: str) -> list[str]:
+    return [m.strip() for m in raw.split(",") if m.strip()]

--- a/climate/sync.py
+++ b/climate/sync.py
@@ -345,37 +345,42 @@ def cmd_comforts_sync(args) -> None:
         sys.exit(1)
 
 
-def cmd_weather_discover(args) -> None:
-    import os
+def cmd_locations(args) -> None:
+    from climate.locations import resolve_locations
+
+    try:
+        locations = resolve_locations(args.location)
+    except RuntimeError as e:
+        print(e)
+        sys.exit(1)
+
+    print(f"{len(locations)} location(s) configured:\n")
+    for loc in locations:
+        macs = ", ".join(loc.station_macs) if loc.station_macs else "(none)"
+        print(f"  {loc.slug}  {loc.label}")
+        print(f"      coords:   ({loc.lat:.4f}, {loc.lon:.4f})")
+        print(f"      stations: {macs}")
+
+
+def _discover_at(loc, radius: float) -> None:
+    """Discover and print nearby outdoor stations for one location."""
     from climate.ambient.client import discover_stations_sync
 
-    lat_str = os.environ.get("HOME_LAT", "")
-    lon_str = os.environ.get("HOME_LON", "")
-    if not lat_str or not lon_str:
-        print("HOME_LAT and HOME_LON must be set. Run 'just dotenv'.")
-        sys.exit(1)
+    print(f"Searching within {radius} mile(s) of ({loc.lat:.4f}, {loc.lon:.4f})...")
     try:
-        lat, lon = float(lat_str), float(lon_str)
-    except ValueError:
-        print(f"HOME_LAT/HOME_LON are not valid floats: {lat_str!r}, {lon_str!r}")
-        sys.exit(1)
-
-    print(f"Searching within {args.radius} mile(s) of ({lat:.4f}, {lon:.4f})...")
-    try:
-        stations = discover_stations_sync(lat, lon, radius_miles=args.radius)
+        stations = discover_stations_sync(loc.lat, loc.lon, radius_miles=radius)
     except RuntimeError as e:
         print(f"Discovery failed: {e}")
-        sys.exit(1)
+        return
 
     if not stations:
         print("No outdoor stations found. Try --radius 1 or larger.")
-        sys.exit(1)
+        return
 
-    from climate.ambient.client import is_temp_plausible
     temps = [s.get("lastData", {}).get("tempf") for s in stations if s.get("lastData", {}).get("tempf") is not None]
     median_temp = sorted(temps)[len(temps) // 2] if temps else None
 
-    print(f"\nFound {len(stations)} outdoor station(s):\n")
+    print(f"Found {len(stations)} outdoor station(s):\n")
     for s in stations:
         mac = s.get("macAddress", "unknown")
         name = (s.get("info", {}).get("name")
@@ -388,40 +393,76 @@ def cmd_weather_discover(args) -> None:
         else:
             temp_str = f"{temp}°F"
         print(f"  {mac}  {name}  ({temp_str})")
-    print("\nStore chosen MACs in 1Password → AMBIENT_STATION_MACS in .env (see .env.template).")
+
+
+def cmd_weather_discover(args) -> None:
+    from climate.locations import resolve_locations
+
+    try:
+        locations = resolve_locations(args.location)
+    except RuntimeError as e:
+        print(e)
+        sys.exit(1)
+
+    multi = len(locations) > 1
+    for loc in locations:
+        if multi:
+            print(f"\n=== {loc.label} ===")
+        _discover_at(loc, args.radius)
+
+    print("\nStore chosen MACs on the location's 1Password item (station_macs field), "
+          "then run 'just dotenv'. Legacy single-home setups: set AMBIENT_STATION_MACS in .env.")
 
 
 def cmd_weather(args) -> None:
-    from climate.ambient.client import load_weather_config, get_configured_macs, get_outdoor_temp_from_stations
+    from climate.ambient.client import load_weather_config, get_outdoor_temp_from_stations
+    from climate.locations import resolve_locations
 
+    # Thresholds are location-agnostic; stations now come per-location.
     config = load_weather_config(args.weather)
-    macs = get_configured_macs(config)
-
-    if not macs:
-        print("No stations configured. Run 'just climate-weather-discover', then set AMBIENT_STATION_MACS in .env.")
-        sys.exit(1)
-
-    result = get_outdoor_temp_from_stations(macs)
-    if result is None:
-        print("Could not read a fresh, plausible outdoor temp from any configured station.")
-        sys.exit(1)
-
-    mac, temp, age_minutes = result
-    age_str = f"{age_minutes:.0f} min old"
-
     thresholds = config.get("thresholds", {})
     heat_below = thresholds.get("heat_below", 60)
     cool_above = thresholds.get("cool_above", 65)
 
-    if temp < heat_below:
-        mode = f"heat  → Comfort Heat (smart2)"
-    elif temp > cool_above:
-        mode = f"cool  → Comfort Cool (smart1)"
-    else:
-        mode = f"neutral  (between {heat_below}°F–{cool_above}°F, no change recommended)"
+    try:
+        locations = resolve_locations(args.location)
+    except RuntimeError as e:
+        print(e)
+        sys.exit(1)
 
-    print(f"Outdoor temp: {temp}°F  ({age_str}, {mac})")
-    print(f"Comfort mode: {mode}")
+    multi = len(locations) > 1
+    any_error = False
+    for loc in locations:
+        if multi:
+            print(f"\n=== {loc.label} ===")
+
+        if not loc.station_macs:
+            print("No stations configured for this location. Run "
+                  "'just climate-weather-discover', then add station_macs in 1Password.")
+            any_error = True
+            continue
+
+        result = get_outdoor_temp_from_stations(loc.station_macs)
+        if result is None:
+            print("Could not read a fresh, plausible outdoor temp from any configured station.")
+            any_error = True
+            continue
+
+        mac, temp, age_minutes = result
+        age_str = f"{age_minutes:.0f} min old"
+
+        if temp < heat_below:
+            mode = "heat  → Comfort Heat (smart2)"
+        elif temp > cool_above:
+            mode = "cool  → Comfort Cool (smart1)"
+        else:
+            mode = f"neutral  (between {heat_below}°F–{cool_above}°F, no change recommended)"
+
+        print(f"Outdoor temp: {temp}°F  ({age_str}, {mac})")
+        print(f"Comfort mode: {mode}")
+
+    if any_error:
+        sys.exit(1)
 
 
 def _apply_comfort_mode(schedule_text: str, mode: str) -> str:
@@ -622,60 +663,59 @@ def cmd_comfort_switch(args) -> None:
 
 def cmd_air_quality(args) -> None:
     import asyncio
-    import os
     from climate.outdoor_air.client import AirQualityError, format_air_quality
     from climate.outdoor_air.pollen import PollenError, format_pollen, get_api_key
     from climate.outdoor_air import client as aq_client
     from climate.outdoor_air import pollen as pollen_client
+    from climate.locations import resolve_locations
 
-    lat_str = os.environ.get("HOME_LAT", "")
-    lon_str = os.environ.get("HOME_LON", "")
-    if not lat_str or not lon_str:
-        print("HOME_LAT and HOME_LON must be set. Run 'just dotenv'.")
-        sys.exit(1)
     try:
-        lat, lon = float(lat_str), float(lon_str)
-    except ValueError:
-        print(f"HOME_LAT/HOME_LON are not valid floats: {lat_str!r}, {lon_str!r}")
+        locations = resolve_locations(args.location)
+    except RuntimeError as e:
+        print(e)
         sys.exit(1)
 
-    # Check for pollen API key before kicking off fetches
+    # Check for pollen API key once before kicking off fetches
     try:
         api_key = get_api_key()
     except PollenError as e:
         api_key = None
         pollen_warning = str(e)
 
-    async def fetch_all():
+    async def fetch_all(lat: float, lon: float):
         tasks = [aq_client._fetch(lat, lon)]
         if api_key:
             tasks.append(pollen_client._fetch(lat, lon, api_key))
         return await asyncio.gather(*tasks, return_exceptions=True)
 
-    results = asyncio.run(fetch_all())
-    aq_result = results[0]
-    pollen_result = results[1] if api_key else None
-
+    multi = len(locations) > 1
     any_error = False
+    for loc in locations:
+        if multi:
+            print(f"\n=== {loc.label} ===")
 
-    if isinstance(aq_result, AirQualityError):
-        print(f"Air quality unavailable: {aq_result}", file=sys.stderr)
-        any_error = True
-    elif isinstance(aq_result, Exception):
-        print(f"Unexpected error fetching air quality: {aq_result}", file=sys.stderr)
-        any_error = True
-    else:
-        print(format_air_quality(aq_result))
+        results = asyncio.run(fetch_all(loc.lat, loc.lon))
+        aq_result = results[0]
+        pollen_result = results[1] if api_key else None
 
-    if api_key is None:
-        print(f"\n(pollen skipped: {pollen_warning})")
-    elif isinstance(pollen_result, PollenError):
-        print(f"\nPollen unavailable: {pollen_result}", file=sys.stderr)
-    elif isinstance(pollen_result, Exception):
-        print(f"\nUnexpected error fetching pollen: {pollen_result}", file=sys.stderr)
-    else:
-        print()
-        print(format_pollen(pollen_result))
+        if isinstance(aq_result, AirQualityError):
+            print(f"Air quality unavailable: {aq_result}", file=sys.stderr)
+            any_error = True
+        elif isinstance(aq_result, Exception):
+            print(f"Unexpected error fetching air quality: {aq_result}", file=sys.stderr)
+            any_error = True
+        else:
+            print(format_air_quality(aq_result))
+
+        if api_key is None:
+            print(f"\n(pollen skipped: {pollen_warning})")
+        elif isinstance(pollen_result, PollenError):
+            print(f"\nPollen unavailable: {pollen_result}", file=sys.stderr)
+        elif isinstance(pollen_result, Exception):
+            print(f"\nUnexpected error fetching pollen: {pollen_result}", file=sys.stderr)
+        else:
+            print()
+            print(format_pollen(pollen_result))
 
     if any_error:
         sys.exit(1)
@@ -827,6 +867,15 @@ def main() -> None:
         help="Path to thermostats YAML (default: climate/config/thermostats.yaml)",
     )
 
+    subparsers.add_parser(
+        "locations", help="List configured locations (main house, beachhouse, ...)"
+    ).add_argument(
+        "--location",
+        metavar="SLUG",
+        default=None,
+        help="Limit to one location by slug (default: all)",
+    )
+
     discover_parser = subparsers.add_parser(
         "discover-stations", help="List nearby outdoor Ambient Weather stations"
     )
@@ -836,6 +885,12 @@ def main() -> None:
         default=0.5,
         metavar="N",
         help="Search radius in miles (default: 0.5)",
+    )
+    discover_parser.add_argument(
+        "--location",
+        metavar="SLUG",
+        default=None,
+        help="Limit to one location by slug (default: all configured locations)",
     )
 
     weather_parser = subparsers.add_parser(
@@ -847,6 +902,12 @@ def main() -> None:
         default=DEFAULT_WEATHER_PATH,
         metavar="PATH",
         help="Path to weather YAML (default: climate/config/weather.yaml)",
+    )
+    weather_parser.add_argument(
+        "--location",
+        metavar="SLUG",
+        default=None,
+        help="Limit to one location by slug (default: all configured locations)",
     )
 
     comfort_switch_parser = subparsers.add_parser(
@@ -892,6 +953,12 @@ def main() -> None:
     air_quality_parser = subparsers.add_parser(
         "air-quality", help="Show current outdoor air quality, UV index, and pollen"
     )
+    air_quality_parser.add_argument(
+        "--location",
+        metavar="SLUG",
+        default=None,
+        help="Limit to one location by slug (default: all configured locations)",
+    )
 
     subparsers.choices["auth"].set_defaults(func=cmd_auth)
     subparsers.choices["list"].set_defaults(func=cmd_list)
@@ -901,6 +968,7 @@ def main() -> None:
     subparsers.choices["history"].set_defaults(func=cmd_history)
     subparsers.choices["capture-comforts"].set_defaults(func=cmd_comforts_capture)
     subparsers.choices["sync-comforts"].set_defaults(func=cmd_comforts_sync)
+    subparsers.choices["locations"].set_defaults(func=cmd_locations)
     subparsers.choices["discover-stations"].set_defaults(func=cmd_weather_discover)
     subparsers.choices["weather"].set_defaults(func=cmd_weather)
     subparsers.choices["comfort-switch"].set_defaults(func=cmd_comfort_switch)

--- a/climate/sync.py
+++ b/climate/sync.py
@@ -360,6 +360,7 @@ def cmd_locations(args) -> None:
         print(f"  {loc.slug}  {loc.label}")
         print(f"      coords:   ({loc.lat:.4f}, {loc.lon:.4f})")
         print(f"      stations: {macs}")
+        print(f"      comfort:  {'managed (comfort-mode recommendation)' if loc.comfort_mode else 'weather-only'}")
 
 
 def _discover_at(loc, radius: float) -> None:
@@ -450,6 +451,12 @@ def cmd_weather(args) -> None:
 
         mac, temp, age_minutes = result
         age_str = f"{age_minutes:.0f} min old"
+        print(f"Outdoor temp: {temp}°F  ({age_str}, {mac})")
+
+        # The comfort-mode line is an Ecobee-specific (smart1/smart2) recommendation,
+        # only meaningful for a location whose thermostat this tooling manages.
+        if not loc.comfort_mode:
+            continue
 
         if temp < heat_below:
             mode = "heat  → Comfort Heat (smart2)"
@@ -457,8 +464,6 @@ def cmd_weather(args) -> None:
             mode = "cool  → Comfort Cool (smart1)"
         else:
             mode = f"neutral  (between {heat_below}°F–{cool_above}°F, no change recommended)"
-
-        print(f"Outdoor temp: {temp}°F  ({age_str}, {mac})")
         print(f"Comfort mode: {mode}")
 
     if any_error:

--- a/scripts/dotenv
+++ b/scripts/dotenv
@@ -36,6 +36,26 @@ op inject -f -i "$TEMPLATE" -o "$tmp"
 # Wrap multiline/space-containing values in double quotes so python-dotenv can parse them.
 scripts/quote-env-values "$tmp"
 
+# Discover named locations: every 1Password item tagged `picklehome-location`
+# becomes one entry in the PICKLEHOME_LOCATIONS JSON array (climate/locations.py
+# parses it). This can't be an op:// template ref because the item set is dynamic,
+# so we query by tag here, mirroring the Lutron cert loop below.
+# Appended after quote-env-values (which would mangle the embedded JSON) and
+# single-quoted by hand; the jq filter strips single quotes to keep that safe.
+LOCATION_TAG="picklehome-location"
+locations_json="[]"
+if item_list=$(op item list --tags "$LOCATION_TAG" --format json 2>/dev/null) \
+   && [[ "$(echo "$item_list" | jq 'length')" -gt 0 ]]; then
+    items_tmp=$(mktemp)
+    for id in $(echo "$item_list" | jq -r '.[].id'); do
+        op item get "$id" --format json >> "$items_tmp"
+    done
+    locations_json=$(jq -sc -f scripts/locations-filter.jq "$items_tmp")
+    rm -f "$items_tmp"
+    echo "Discovered $(echo "$locations_json" | jq 'length') location(s) tagged '$LOCATION_TAG'"
+fi
+printf "PICKLEHOME_LOCATIONS='%s'\n" "$locations_json" >> "$tmp"
+
 # Verify no keys disappeared before clobbering the real file
 if [[ -n "$old_keys" ]]; then
     new_keys=$(grep -v '^#' "$tmp" | grep -v '^[[:space:]]*$' | cut -d= -f1 | sort)

--- a/scripts/locations-filter.jq
+++ b/scripts/locations-filter.jq
@@ -1,0 +1,29 @@
+# Transform a stream of `op item get --format json` objects into the
+# PICKLEHOME_LOCATIONS array consumed by climate/locations.py.
+#
+# Each 1Password item tagged `picklehome-location` contributes one location.
+# Custom fields are matched by label: slug, label, latitude, longitude,
+# station_macs (comma-separated). latitude/longitude are required; items
+# missing either are skipped.
+#
+# Run over the slurped stream: jq -sc -f scripts/locations-filter.jq
+map(
+  (reduce (.fields // [])[] as $f ({}; .[$f.label] = $f.value)) as $m
+  | select($m.latitude and $m.longitude)
+  | {
+      slug: ($m.slug // (.title | ascii_downcase | gsub("[^a-z0-9]+"; "-"))),
+      label: ($m.label // .title),
+      lat: ($m.latitude | tonumber),
+      lon: ($m.longitude | tonumber),
+      station_macs: (
+        ($m.station_macs // "")
+        | split(",")
+        | map(gsub("^\\s+|\\s+$"; ""))
+        | map(select(length > 0))
+      )
+    }
+  # Strip single quotes so the value is safe inside a single-quoted .env line.
+  | walk(if type == "string" then gsub("'"; "") else . end)
+)
+# Home first (the Atlanta default), then alphabetical by slug.
+| sort_by(.slug != "home", .slug)

--- a/scripts/locations-filter.jq
+++ b/scripts/locations-filter.jq
@@ -3,7 +3,8 @@
 #
 # Each 1Password item tagged `picklehome-location` contributes one location.
 # Custom fields are matched by label: slug, label, latitude, longitude,
-# station_macs (comma-separated). latitude/longitude are required; items
+# station_macs (comma-separated), comfort_mode ("true" if this location has a
+# thermostat this tooling manages). latitude/longitude are required; items
 # missing either are skipped.
 #
 # Run over the slurped stream: jq -sc -f scripts/locations-filter.jq
@@ -20,7 +21,8 @@ map(
         | split(",")
         | map(gsub("^\\s+|\\s+$"; ""))
         | map(select(length > 0))
-      )
+      ),
+      comfort_mode: (($m.comfort_mode // "") | ascii_downcase == "true")
     }
   # Strip single quotes so the value is safe inside a single-quoted .env line.
   | walk(if type == "string" then gsub("'"; "") else . end)

--- a/tests/climate/test_locations.py
+++ b/tests/climate/test_locations.py
@@ -20,10 +20,16 @@ def _set_locations(monkeypatch, data):
 
 def test_json_path_parses_all_fields(monkeypatch):
     _set_locations(monkeypatch, [
-        {"slug": "home", "label": "Main House", "lat": 33.77, "lon": -84.38, "station_macs": ["AA:BB"]},
+        {"slug": "home", "label": "Main House", "lat": 33.77, "lon": -84.38,
+         "station_macs": ["AA:BB"], "comfort_mode": True},
     ])
     locs = load_locations()
-    assert locs == [Location("home", "Main House", 33.77, -84.38, ["AA:BB"])]
+    assert locs == [Location("home", "Main House", 33.77, -84.38, ["AA:BB"], comfort_mode=True)]
+
+
+def test_comfort_mode_defaults_false(monkeypatch):
+    _set_locations(monkeypatch, [{"slug": "beachhouse", "lat": 41.9, "lon": -70.6}])
+    assert load_locations()[0].comfort_mode is False
 
 
 def test_label_defaults_to_slug(monkeypatch):
@@ -42,7 +48,7 @@ def test_legacy_fallback_synthesizes_home(monkeypatch):
     monkeypatch.setenv("HOME_LON", "-84.38")
     monkeypatch.setenv("AMBIENT_STATION_MACS", "AA:BB, CC:DD")
     locs = load_locations()
-    assert locs == [Location("home", "Home", 33.77, -84.38, ["AA:BB", "CC:DD"])]
+    assert locs == [Location("home", "Home", 33.77, -84.38, ["AA:BB", "CC:DD"], comfort_mode=True)]
 
 
 def test_empty_json_array_falls_back_to_legacy(monkeypatch):

--- a/tests/climate/test_locations.py
+++ b/tests/climate/test_locations.py
@@ -1,0 +1,103 @@
+"""Tests for climate.locations: PICKLEHOME_LOCATIONS parsing + legacy fallback."""
+
+import json
+
+import pytest
+
+from climate.locations import Location, load_locations, resolve_locations
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Start each test with no location env vars set."""
+    for key in ("PICKLEHOME_LOCATIONS", "HOME_LAT", "HOME_LON", "AMBIENT_STATION_MACS"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _set_locations(monkeypatch, data):
+    monkeypatch.setenv("PICKLEHOME_LOCATIONS", json.dumps(data))
+
+
+def test_json_path_parses_all_fields(monkeypatch):
+    _set_locations(monkeypatch, [
+        {"slug": "home", "label": "Main House", "lat": 33.77, "lon": -84.38, "station_macs": ["AA:BB"]},
+    ])
+    locs = load_locations()
+    assert locs == [Location("home", "Main House", 33.77, -84.38, ["AA:BB"])]
+
+
+def test_label_defaults_to_slug(monkeypatch):
+    _set_locations(monkeypatch, [{"slug": "beachhouse", "lat": 41.9, "lon": -70.6}])
+    assert load_locations()[0].label == "beachhouse"
+
+
+def test_lat_lon_coerced_from_strings(monkeypatch):
+    _set_locations(monkeypatch, [{"slug": "home", "lat": "33.77", "lon": "-84.38"}])
+    loc = load_locations()[0]
+    assert (loc.lat, loc.lon) == (33.77, -84.38)
+
+
+def test_legacy_fallback_synthesizes_home(monkeypatch):
+    monkeypatch.setenv("HOME_LAT", "33.77")
+    monkeypatch.setenv("HOME_LON", "-84.38")
+    monkeypatch.setenv("AMBIENT_STATION_MACS", "AA:BB, CC:DD")
+    locs = load_locations()
+    assert locs == [Location("home", "Home", 33.77, -84.38, ["AA:BB", "CC:DD"])]
+
+
+def test_empty_json_array_falls_back_to_legacy(monkeypatch):
+    monkeypatch.setenv("PICKLEHOME_LOCATIONS", "[]")
+    monkeypatch.setenv("HOME_LAT", "33.77")
+    monkeypatch.setenv("HOME_LON", "-84.38")
+    assert load_locations()[0].slug == "home"
+
+
+def test_json_takes_precedence_over_legacy(monkeypatch):
+    _set_locations(monkeypatch, [{"slug": "beachhouse", "lat": 41.9, "lon": -70.6}])
+    monkeypatch.setenv("HOME_LAT", "33.77")
+    monkeypatch.setenv("HOME_LON", "-84.38")
+    assert [loc.slug for loc in load_locations()] == ["beachhouse"]
+
+
+def test_nothing_configured_returns_empty(monkeypatch):
+    assert load_locations() == []
+
+
+def test_invalid_json_raises(monkeypatch):
+    monkeypatch.setenv("PICKLEHOME_LOCATIONS", "{not json")
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        load_locations()
+
+
+def test_legacy_bad_floats_raise(monkeypatch):
+    monkeypatch.setenv("HOME_LAT", "nope")
+    monkeypatch.setenv("HOME_LON", "-84.38")
+    with pytest.raises(RuntimeError, match="not valid floats"):
+        load_locations()
+
+
+def test_resolve_all(monkeypatch):
+    _set_locations(monkeypatch, [
+        {"slug": "home", "lat": 1, "lon": 2},
+        {"slug": "beachhouse", "lat": 3, "lon": 4},
+    ])
+    assert [loc.slug for loc in resolve_locations()] == ["home", "beachhouse"]
+
+
+def test_resolve_by_slug_case_insensitive(monkeypatch):
+    _set_locations(monkeypatch, [
+        {"slug": "home", "lat": 1, "lon": 2},
+        {"slug": "beachhouse", "lat": 3, "lon": 4},
+    ])
+    assert [loc.slug for loc in resolve_locations("BEACHHOUSE")] == ["beachhouse"]
+
+
+def test_resolve_unknown_slug_raises_with_available(monkeypatch):
+    _set_locations(monkeypatch, [{"slug": "home", "lat": 1, "lon": 2}])
+    with pytest.raises(RuntimeError, match="Unknown location 'nope'. Available: home"):
+        resolve_locations("nope")
+
+
+def test_resolve_nothing_configured_raises(monkeypatch):
+    with pytest.raises(RuntimeError, match="No locations configured"):
+        resolve_locations()


### PR DESCRIPTION
## What

Weather and air-quality commands now cover **every configured location** (Atlanta main house, MA beachhouse, ...) by default, grouped in the output like `locks` groups by home. `--location <slug>` filters to one.

## How locations work

Each location is a **1Password item tagged `picklehome-location`** with fields: `slug`, `label`, `latitude`, `longitude`, `station_macs` (comma-separated). `just dotenv` discovers every tagged item and snapshots them into the `PICKLEHOME_LOCATIONS` JSON var in `.env` (via `scripts/locations-filter.jq`); `climate/locations.py` parses it at runtime.

- **Self-registering:** add/edit an address in 1Password, re-run `just dotenv`, done. No template or code edits per address.
- **Geolocatable data stays out of the repo:** coords + MACs live only in the gitignored `.env`.
- **Backward compatible:** falls back to the legacy single-home `HOME_LAT`/`HOME_LON`/`AMBIENT_STATION_MACS` vars when no items are tagged.

## Commands

- `just climate-locations [--location SLUG]` — list configured locations (new)
- `just climate-weather [--location SLUG]`
- `just climate-weather-discover [--location SLUG]`
- `just climate-air-quality [--location SLUG]`

`comfort-switch` is intentionally left single-location (it drives the Atlanta auto-switch service).

## Verified with live data

Both homes report on both commands (Atlanta + 8 Hacker St, Fairhaven MA). `uv run pytest tests/climate/` → 102 passed, incl. 13 new location tests.

## Follow-up (not this PR)

The location data shape (`slug`/`label`/`lat`/`lon` + tagged items) is designed so the Nest integration (task 5457642f) can adopt it. Worth promoting `climate/locations.py` to a shared `picklehome/locations.py` when Nest lands.

Closes task 026a0249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)