### PR TITLE
docs(claude): 1Password label whitespace gotcha + picklehome package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Secrets are stored in 1Password and injected into `.env` via `op inject`. Most s
 
 The logic lives in `scripts/dotenv` (supports `--template`, `--output`, `--force`).
 
+**Gotcha:** 1Password field labels feeding `op inject` / `scripts/locations-filter.jq` must have no leading/trailing whitespace. A stray space (e.g. `" yale_houses"`) silently drops the field from the generated `.env` with no error, so a location value just quietly goes missing.
+
 Scripts load `.env` automatically via `python-dotenv` (or `just`'s `set dotenv-load`).
 
 ## Sandbox
@@ -144,6 +146,7 @@ See @docs/CONVENTIONS.md for where information belongs (code comments vs README 
 - `garage/`: Aladdin Connect garage door control; see `garage/README.md`
 - `locks/`: Yale Access smart locks; see `locks/README.md`
 - `sonos/`: Sonos speaker health checks (local, no auth); see `sonos/README.md`
+- `picklehome/`: Shared cross-module code. `locations.py` is the canonical location registry (main house, beachhouse, ...) consumed by climate and locks; see `climate/README.md` and `locks/README.md`
 - `homelab/`: NUC server services and infrastructure; see `homelab/README.md`
   - Key services: `obsidian-sync` (vaults: `rpg`, `pickled-knowledge`), `brineworks-server`, `brineworks-agent`, `second-brain-agent`, `taskchampion-sync`, `climate-auto-switch`, `backup`, `github-actions-runner`, `woodpecker` (full list in the Homelab Services table below)
   - **Obsidian vaults on host:** `/srv/data/obsidian-sync/vaults/<vault>/` — `pickled-knowledge` is the personal knowledge base (second brain); `rpg` is campaign notes


### PR DESCRIPTION
Session learnings from PR #95 (shared locations registry).

- **Whitespace gotcha:** a leading/trailing space in a 1Password field label silently drops that field from `just dotenv` / `scripts/locations-filter.jq` (no error). This is what hid `yale_houses` on the home location during testing.
- **Directories index:** add the new shared `picklehome/` package (canonical location registry consumed by climate + locks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)